### PR TITLE
Android createPDFFromMultipleImages wihtout configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.1
+### Android
+* Fixed `createPDFFromMultipleImages` without configuration. [#35](https://github.com/vicajilau/pdf_combiner/issues/35)
+
 ## 4.1.0
 ### General
 * Improved documentation.

--- a/example/lib/view_models/pdf_combiner_view_model.dart
+++ b/example/lib/view_models/pdf_combiner_view_model.dart
@@ -122,8 +122,7 @@ class PdfCombinerViewModel {
 
   // Function to get the appropriate directory for saving the output file
   Future<Directory?> _getOutputDirectory() async {
-    if (PlatformDetail.isIOS ||
-        PlatformDetail.isDesktop) {
+    if (PlatformDetail.isIOS || PlatformDetail.isDesktop) {
       return await getApplicationDocumentsDirectory(); // For iOS & Desktop, return the documents directory
     } else if (PlatformDetail.isAndroid) {
       return await getDownloadsDirectory(); // For Android, return the Downloads directory

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pdf_combiner
 description: "It is a lightweight and efficient Flutter plugin designed to merge multiple PDF documents into a single file effortlessly."
-version: 4.1.0
+version: 4.1.1
 homepage: https://github.com/vicajilau/pdf_combiner
 
 environment:


### PR DESCRIPTION
Resolved https://github.com/vicajilau/pdf_combiner/issues/35 When calling PdfCombiner.createPDFFromMultipleImages without providing a configuration, an exception occurs on Android because the image width and height are set to 0.