### PR TITLE
Feature/fix issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+
+## 4.2.2
+### General
+* Fixed `createPDF` When selecting the option to create a PDF with two or more images, the process fails, and no PDF is generated. [#40](https://github.com/vicajilau/pdf_combiner/issues/40)
 ## 4.2.1
 ### General
 * Improved documentation.

--- a/example/lib/view_models/pdf_combiner_view_model.dart
+++ b/example/lib/view_models/pdf_combiner_view_model.dart
@@ -114,10 +114,9 @@ class PdfCombinerViewModel {
   /// Function to create a PDF file from a list of documents
   Future<void> createPDFFromDocuments() async {
     if (selectedFiles.isEmpty) return; // If no files are selected, do nothing
-    String outputFilePath = "combined_output.pdf";
     try {
         final directory = await _getOutputDirectory();
-        outputFilePath = '${directory?.path}/combined_output.pdf';
+        String outputFilePath = '${directory?.path}';
       final response = await PdfCombiner.generatePDFFromDocuments(
         inputPaths: selectedFiles,
         outputPath: outputFilePath,

--- a/lib/pdf_combiner.dart
+++ b/lib/pdf_combiner.dart
@@ -76,7 +76,7 @@ class PdfCombiner {
         } else {
           if (isImage) {
             final response = await PdfCombiner.createPDFFromMultipleImages(
-                inputPaths: [path], outputPath: outputPath);
+                inputPaths: [path], outputPath: "$outputPath/document_$i.pdf");
             if (response.status == PdfCombinerStatus.success) {
               mutablePaths[i] = response.outputPath;
             } else {
@@ -91,7 +91,7 @@ class PdfCombiner {
       }
       final response = await PdfCombiner.mergeMultiplePDFs(
         inputPaths: mutablePaths,
-        outputPath: outputPath,
+        outputPath: "$outputPath/outpath.pdf",
       );
       if (response.status == PdfCombinerStatus.success) {
         return GeneratePdfFromDocumentsResponse(

--- a/test/pdf_combiner_generate_from_documents_test.dart
+++ b/test/pdf_combiner_generate_from_documents_test.dart
@@ -14,7 +14,7 @@ import 'mocks/mock_pdf_combiner_platform_with_exception.dart';
 void main() {
   group('PdfCombiner Generate From Document Unit Tests', () {
     late File testFile1;
-    final String testFilePath1 = 'output_path.pdf';
+    final String testFilePath1 = 'document_0.pdf';
     PdfCombiner.isMock = true;
 
     setUp(() async {
@@ -54,12 +54,12 @@ void main() {
           'example/assets/document_1.pdf',
           'example/assets/document_2.pdf'
         ],
-        outputPath: 'output/path.pdf',
+        outputPath: 'output',
       );
 
       // Verify the result matches the expected mock values.
       expect(result.status, PdfCombinerStatus.success);
-      expect(result.outputPath, "output/path.pdf");
+      expect(result.outputPath, "output/outpath.pdf");
       expect(result.message, 'Processed successfully');
       expect(result.toString(),
           'GeneratePdfFromDocumentsResponse{outputPath: ${result.outputPath}, message: ${result.message}, status: ${result.status} }');
@@ -78,11 +78,11 @@ void main() {
           'example/assets/image_1.jpeg',
           'example/assets/document_1.pdf',
         ],
-        outputPath: 'output_path.pdf',
+        outputPath: 'output',
       );
       // Verify the result matches the expected mock values.
       expect(result.status, PdfCombinerStatus.success);
-      expect(result.outputPath, "output_path.pdf");
+      expect(result.outputPath, "output/outpath.pdf");
       expect(result.message, 'Processed successfully');
       expect(result.toString(),
           'GeneratePdfFromDocumentsResponse{outputPath: ${result.outputPath}, message: ${result.message}, status: ${result.status} }');
@@ -90,53 +90,53 @@ void main() {
 
     // Test for successfully combining multiple PDFs using PdfCombiner.
     test('generatePDFFromDocuments File does not exist (PdfCombiner)',
-        () async {
-      MockPdfCombinerPlatform fakePlatform = MockPdfCombinerPlatform();
+            () async {
+          MockPdfCombinerPlatform fakePlatform = MockPdfCombinerPlatform();
 
-      // Replace the platform instance with the mock implementation.
-      PdfCombinerPlatform.instance = fakePlatform;
+          // Replace the platform instance with the mock implementation.
+          PdfCombinerPlatform.instance = fakePlatform;
 
-      // Call the method and check the response.
-      final result = await PdfCombiner.generatePDFFromDocuments(
-        inputPaths: [
-          'example/assets/document_1.pdf',
-          'example/assets/image_1.jpeg'
-        ],
-        outputPath: 'output-path.pdf',
-      );
-      // Verify the result matches the expected mock values.
-      expect(result.status, PdfCombinerStatus.error);
-      expect(result.outputPath, "");
-      expect(result.message,
-          'File is not of PDF type or does not exist: output-path.pdf');
-      expect(result.toString(),
-          'GeneratePdfFromDocumentsResponse{outputPath: ${result.outputPath}, message: ${result.message}, status: ${result.status} }');
-    });
+          // Call the method and check the response.
+          final result = await PdfCombiner.generatePDFFromDocuments(
+            inputPaths: [
+              'example/assets/document_1.pdf',
+              'example/assets/image_1.jpeg'
+            ],
+            outputPath: 'output',
+          );
+          // Verify the result matches the expected mock values.
+          expect(result.status, PdfCombinerStatus.error);
+          expect(result.outputPath, "");
+          expect(result.message,
+              'File is not of PDF type or does not exist: output/document_1.pdf');
+          expect(result.toString(),
+              'GeneratePdfFromDocumentsResponse{outputPath: ${result.outputPath}, message: ${result.message}, status: ${result.status} }');
+        });
 
     // Test for successfully combining multiple PDFs using PdfCombiner.
     test('generatePDFFromDocuments File does not exist (PdfCombiner)',
-        () async {
-      MockPdfCombinerPlatform fakePlatform = MockPdfCombinerPlatform();
+            () async {
+          MockPdfCombinerPlatform fakePlatform = MockPdfCombinerPlatform();
 
-      // Replace the platform instance with the mock implementation.
-      PdfCombinerPlatform.instance = fakePlatform;
+          // Replace the platform instance with the mock implementation.
+          PdfCombinerPlatform.instance = fakePlatform;
 
-      // Call the method and check the response.
-      final result = await PdfCombiner.generatePDFFromDocuments(
-        inputPaths: [
-          'example/assets/document_1.pdf',
-          'example/assets/image_1.jpeg'
-        ],
-        outputPath: 'output-path.pdf',
-      );
-      // Verify the result matches the expected mock values.
-      expect(result.status, PdfCombinerStatus.error);
-      expect(result.outputPath, "");
-      expect(result.message,
-          'File is not of PDF type or does not exist: output-path.pdf');
-      expect(result.toString(),
-          'GeneratePdfFromDocumentsResponse{outputPath: ${result.outputPath}, message: ${result.message}, status: ${result.status} }');
-    });
+          // Call the method and check the response.
+          final result = await PdfCombiner.generatePDFFromDocuments(
+            inputPaths: [
+              'example/assets/document_1.pdf',
+              'example/assets/image_1.jpeg'
+            ],
+            outputPath: 'output',
+          );
+          // Verify the result matches the expected mock values.
+          expect(result.status, PdfCombinerStatus.error);
+          expect(result.outputPath, "");
+          expect(result.message,
+              'File is not of PDF type or does not exist: output/document_1.pdf');
+          expect(result.toString(),
+              'GeneratePdfFromDocumentsResponse{outputPath: ${result.outputPath}, message: ${result.message}, status: ${result.status} }');
+        });
 
     // Test for successfully combining multiple PDFs using PdfCombiner.
     test('generatePDFFromDocuments File PDF issue (PdfCombiner)', () async {
@@ -151,13 +151,13 @@ void main() {
           'example/assets/image_1.jpeg',
           'example/assets/image_2.png'
         ],
-        outputPath: 'output-path.pdf',
+        outputPath: 'output',
       );
       // Verify the result matches the expected mock values.
       expect(result.status, PdfCombinerStatus.error);
       expect(result.outputPath, "");
       expect(result.message,
-          'File is not of PDF type or does not exist: output-path.pdf');
+          'File is not of PDF type or does not exist: output/document_0.pdf');
       expect(result.toString(),
           'GeneratePdfFromDocumentsResponse{outputPath: ${result.outputPath}, message: ${result.message}, status: ${result.status} }');
     });
@@ -189,7 +189,7 @@ void main() {
     test('combine - Error empty inputPaths', () async {
       // Create a mock platform that simulates an error during PDF merging.
       MockPdfCombinerPlatformWithError fakePlatformWithError =
-          MockPdfCombinerPlatformWithError();
+      MockPdfCombinerPlatformWithError();
 
       // Replace the platform instance with the error mock implementation.
       PdfCombinerPlatform.instance = fakePlatformWithError;
@@ -210,7 +210,7 @@ void main() {
     test('combine - Error handling (Only PDF file allowed)', () async {
       // Create a mock platform that simulates an error during PDF merging.
       MockPdfCombinerPlatformWithError fakePlatformWithError =
-          MockPdfCombinerPlatformWithError();
+      MockPdfCombinerPlatformWithError();
 
       // Replace the platform instance with the error mock implementation.
       PdfCombinerPlatform.instance = fakePlatformWithError;
@@ -251,7 +251,7 @@ void main() {
     // Test for error processing when combining multiple PDFs using PdfCombiner.
     test('combine - Error in processing', () async {
       MockPdfCombinerPlatformWithError fakePlatform =
-          MockPdfCombinerPlatformWithError();
+      MockPdfCombinerPlatformWithError();
 
       // Replace the platform instance with the mock implementation.
       PdfCombinerPlatform.instance = fakePlatform;
@@ -276,7 +276,7 @@ void main() {
     // Test for error processing when combining multiple PDFs using PdfCombiner.
     test('combine - Mocked Exception', () async {
       MockPdfCombinerPlatformWithException fakePlatform =
-          MockPdfCombinerPlatformWithException();
+      MockPdfCombinerPlatformWithException();
 
       // Replace the platform instance with the mock implementation.
       PdfCombinerPlatform.instance = fakePlatform;
@@ -302,7 +302,7 @@ void main() {
     test('combine - Error createPDFFromMultipleImages', () async {
       // Create a mock platform that simulates an error during PDF merging.
       MockPdfCombinerPlatformWithError fakePlatformWithError =
-          MockPdfCombinerPlatformWithError();
+      MockPdfCombinerPlatformWithError();
 
       // Replace the platform instance with the error mock implementation.
       PdfCombinerPlatform.instance = fakePlatformWithError;


### PR DESCRIPTION
- PDF Creation with Multiple Images: Resolved an issue where attempting to create a PDF with two or more images caused the application to fail, preventing PDF generation. The fix ensures that images are properly processed and combined into a single PDF.
issue: https://github.com/vicajilau/pdf_combiner/issues/40