### PR TITLE
PDF Creation fails with multiple images + improved outputPath error management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 4.2.2
 ### General
 * Fixed `createPDF` When selecting the option to create a PDF with two or more images, the process fails, and no PDF is generated. [#40](https://github.com/vicajilau/pdf_combiner/issues/40)
+* Updated error message for invalid `outputPath` to clarify that it must have a `.pdf` format on `generatePDFFromDocuments`, `mergeMultiplePDFs` and `createPDFFromMultipleImages`.
 
 ## 4.2.1
 ### General

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
+## 4.2.2
+### General
+* Fixed `createPDF` When selecting the option to create a PDF with two or more images, the process fails, and no PDF is generated. [#40](https://github.com/vicajilau/pdf_combiner/issues/40)
+
 ## 4.2.1
 ### General
 * Improved documentation.
 * Added more coverage.
 * Improved UI for example project.
-* Fixed an issue where`createPDFFromMultipleImages` was not using the `outputPath` param for the file name.
 ### Web
 * `createPDFFromMultipleImages` did not work without passing a configuration. [#37](https://github.com/vicajilau/pdf_combiner/issues/37)
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Combine any number of PDFs and images, in any order, into a single PDF document.
 
 **Required Parameters:**
 - `inputPaths`: A list of strings representing the image and PDF file paths.
-- `outputPath`: A string representing the absolute path of the file where the generated PDF should be saved. In the case of web, this parameter is ignored.
+- `outputPath`: A string representing the absolute path of the file where the generated PDF should be saved. In the case of web, this parameter is ignored. The file extension must be `.pdf`.
 
 ```dart
 final imagePaths = ["path/to/image1.jpg", "path/to/document1.pdf", "path/to/image2.png"];
@@ -68,7 +68,7 @@ Combine several PDF files into a single document.
 
 **Required Parameters:**
 - `inputPaths`: A list of strings representing the paths of the PDF files to combine.
-- `outputPath`: A string representing the absolute path of the file where the combined PDF should be saved. In the case of web, this parameter is ignored.
+- `outputPath`: A string representing the absolute path of the file where the combined PDF should be saved. In the case of web, this parameter is ignored. The file extension must be `.pdf`.
 
 ```dart
 final filesPath = ["path/to/file1.pdf", "path/to/file2.pdf"];
@@ -93,7 +93,7 @@ Convert a list of image files into a single PDF document.
 
 **Required Parameters:**
 - `inputPaths`: A list of strings representing the image file paths.
-- `outputPath`: A string representing the absolute path of the file where the generated PDF should be saved. In the case of web, this parameter is ignored.
+- `outputPath`: A string representing the absolute path of the file where the generated PDF should be saved. In the case of web, this parameter is ignored. The file extension must be `.pdf`.
 
 By default, images are added to the PDF without modifications. If needed, you can customize the scaling, compression, and aspect ratio using a configuration object.
 

--- a/example/lib/view_models/pdf_combiner_view_model.dart
+++ b/example/lib/view_models/pdf_combiner_view_model.dart
@@ -114,10 +114,9 @@ class PdfCombinerViewModel {
   /// Function to create a PDF file from a list of documents
   Future<void> createPDFFromDocuments() async {
     if (selectedFiles.isEmpty) return; // If no files are selected, do nothing
-    String outputFilePath = "combined_output.pdf";
     try {
       final directory = await _getOutputDirectory();
-      outputFilePath = '${directory?.path}/combined_output.pdf';
+      String outputFilePath = '${directory?.path}/combined_output.jpg';
       final response = await PdfCombiner.generatePDFFromDocuments(
         inputPaths: selectedFiles,
         outputPath: outputFilePath,

--- a/example/lib/view_models/pdf_combiner_view_model.dart
+++ b/example/lib/view_models/pdf_combiner_view_model.dart
@@ -104,10 +104,10 @@ class PdfCombinerViewModel {
         case PdfCombinerStatus.success:
           outputFiles = [response.outputPath];
         case PdfCombinerStatus.error:
-          throw Exception('Error creating PDF: ${response.message}.');
+          throw Exception('${response.message}');
       }
     } catch (e) {
-      throw Exception('Error creating PDF: ${e.toString()}.');
+      throw Exception(e.toString());
     }
   }
 
@@ -127,10 +127,10 @@ class PdfCombinerViewModel {
         case PdfCombinerStatus.success:
           outputFiles = [response.outputPath];
         case PdfCombinerStatus.error:
-          throw Exception('Error creating PDF: ${response.message}.');
+          throw Exception(response.message);
       }
     } catch (e) {
-      throw Exception('Error creating PDF: ${e.toString()}.');
+      throw Exception(e.toString());
     }
   }
 
@@ -155,7 +155,7 @@ class PdfCombinerViewModel {
       if (response.status == PdfCombinerStatus.success) {
         outputFiles = response.outputPaths;
       } else {
-        throw Exception('${response.message}.');
+        throw Exception('${response.message}');
       }
     } catch (e) {
       rethrow;

--- a/example/lib/view_models/pdf_combiner_view_model.dart
+++ b/example/lib/view_models/pdf_combiner_view_model.dart
@@ -116,7 +116,7 @@ class PdfCombinerViewModel {
     if (selectedFiles.isEmpty) return; // If no files are selected, do nothing
     try {
       final directory = await _getOutputDirectory();
-      String outputFilePath = '${directory?.path}/combined_output.jpg';
+      String outputFilePath = '${directory?.path}/combined_output.pdf';
       final response = await PdfCombiner.generatePDFFromDocuments(
         inputPaths: selectedFiles,
         outputPath: outputFilePath,

--- a/lib/pdf_combiner.dart
+++ b/lib/pdf_combiner.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:path/path.dart' as path;
 import 'package:pdf_combiner/isolates/images_from_pdf_isolate.dart';
 import 'package:pdf_combiner/models/pdf_from_multiple_image_config.dart';
 import 'package:pdf_combiner/responses/generate_pdf_from_documents_response.dart';
@@ -64,6 +65,8 @@ class PdfCombiner {
       );
     } else {
       final List<String> mutablePaths = List.from(inputPaths);
+      String dirname = path.dirname(outputPath);
+      print("mi path es: $dirname");
       for (int i = 0; i < mutablePaths.length; i++) {
         final path = mutablePaths[i];
         final isPDF = await DocumentUtils.isPDF(path);
@@ -76,7 +79,7 @@ class PdfCombiner {
         } else {
           if (isImage) {
             final response = await PdfCombiner.createPDFFromMultipleImages(
-                inputPaths: [path], outputPath: outputPath);
+                inputPaths: [path], outputPath: "$dirname/document_$i.pdf");
             if (response.status == PdfCombinerStatus.success) {
               mutablePaths[i] = response.outputPath;
             } else {

--- a/lib/pdf_combiner.dart
+++ b/lib/pdf_combiner.dart
@@ -71,7 +71,13 @@ class PdfCombiner {
         final path = mutablePaths[i];
         final isPDF = await DocumentUtils.isPDF(path);
         final isImage = await DocumentUtils.isImage(path);
-        if (!isPDF && !isImage) {
+        final outputPathIsPDF = await DocumentUtils.hasPDFExtension(outputPath);
+        if(!outputPathIsPDF){
+          return GeneratePdfFromDocumentsResponse(
+            status: PdfCombinerStatus.error,
+            message: PdfCombinerMessages.errorMessageMixedOutputPath(outputPath),
+          );
+        }else if (!isPDF && !isImage) {
           return GeneratePdfFromDocumentsResponse(
             status: PdfCombinerStatus.error,
             message: PdfCombinerMessages.errorMessageMixed(path),
@@ -143,7 +149,13 @@ class PdfCombiner {
           i++;
         }
 
-        if (!success) {
+        final outputPathIsPDF = await DocumentUtils.hasPDFExtension(outputPath);
+        if(!outputPathIsPDF){
+          return MergeMultiplePDFResponse(
+            status: PdfCombinerStatus.error,
+            message: PdfCombinerMessages.errorMessageMixedOutputPath(outputPath),
+          );
+        }else if (!success) {
           return MergeMultiplePDFResponse(
               status: PdfCombinerStatus.error,
               message: PdfCombinerMessages.errorMessagePDF(path));
@@ -190,7 +202,13 @@ class PdfCombiner {
     required String outputPath,
     PdfFromMultipleImageConfig config = const PdfFromMultipleImageConfig(),
   }) async {
-    if (inputPaths.isEmpty) {
+    final outputPathIsPDF = await DocumentUtils.hasPDFExtension(outputPath);
+    if(!outputPathIsPDF){
+      return PdfFromMultipleImageResponse(
+        status: PdfCombinerStatus.error,
+        message: PdfCombinerMessages.errorMessageMixedOutputPath(outputPath),
+      );
+    }else if (inputPaths.isEmpty) {
       return PdfFromMultipleImageResponse(
         status: PdfCombinerStatus.error,
         message: PdfCombinerMessages.emptyParameterMessage("inputPaths"),

--- a/lib/pdf_combiner.dart
+++ b/lib/pdf_combiner.dart
@@ -66,18 +66,18 @@ class PdfCombiner {
     } else {
       final List<String> mutablePaths = List.from(inputPaths);
       String dirname = path.dirname(outputPath);
-      print("mi path es: $dirname");
       for (int i = 0; i < mutablePaths.length; i++) {
         final path = mutablePaths[i];
         final isPDF = await DocumentUtils.isPDF(path);
         final isImage = await DocumentUtils.isImage(path);
-        final outputPathIsPDF = await DocumentUtils.hasPDFExtension(outputPath);
-        if(!outputPathIsPDF){
+        final outputPathIsPDF = DocumentUtils.hasPDFExtension(outputPath);
+        if (!outputPathIsPDF) {
           return GeneratePdfFromDocumentsResponse(
             status: PdfCombinerStatus.error,
-            message: PdfCombinerMessages.errorMessageMixedOutputPath(outputPath),
+            message:
+                PdfCombinerMessages.errorMessageInvalidOutputPath(outputPath),
           );
-        }else if (!isPDF && !isImage) {
+        } else if (!isPDF && !isImage) {
           return GeneratePdfFromDocumentsResponse(
             status: PdfCombinerStatus.error,
             message: PdfCombinerMessages.errorMessageMixed(path),
@@ -149,13 +149,14 @@ class PdfCombiner {
           i++;
         }
 
-        final outputPathIsPDF = await DocumentUtils.hasPDFExtension(outputPath);
-        if(!outputPathIsPDF){
+        final outputPathIsPDF = DocumentUtils.hasPDFExtension(outputPath);
+        if (!outputPathIsPDF) {
           return MergeMultiplePDFResponse(
             status: PdfCombinerStatus.error,
-            message: PdfCombinerMessages.errorMessageMixedOutputPath(outputPath),
+            message:
+                PdfCombinerMessages.errorMessageInvalidOutputPath(outputPath),
           );
-        }else if (!success) {
+        } else if (!success) {
           return MergeMultiplePDFResponse(
               status: PdfCombinerStatus.error,
               message: PdfCombinerMessages.errorMessagePDF(path));
@@ -202,13 +203,13 @@ class PdfCombiner {
     required String outputPath,
     PdfFromMultipleImageConfig config = const PdfFromMultipleImageConfig(),
   }) async {
-    final outputPathIsPDF = await DocumentUtils.hasPDFExtension(outputPath);
-    if(!outputPathIsPDF){
+    final outputPathIsPDF = DocumentUtils.hasPDFExtension(outputPath);
+    if (!outputPathIsPDF) {
       return PdfFromMultipleImageResponse(
         status: PdfCombinerStatus.error,
-        message: PdfCombinerMessages.errorMessageMixedOutputPath(outputPath),
+        message: PdfCombinerMessages.errorMessageInvalidOutputPath(outputPath),
       );
-    }else if (inputPaths.isEmpty) {
+    } else if (inputPaths.isEmpty) {
       return PdfFromMultipleImageResponse(
         status: PdfCombinerStatus.error,
         message: PdfCombinerMessages.emptyParameterMessage("inputPaths"),

--- a/lib/responses/pdf_combiner_messages.dart
+++ b/lib/responses/pdf_combiner_messages.dart
@@ -26,7 +26,11 @@ class PdfCombinerMessages {
   /// - [path] The file path of the invalid or non-existent image.
   static String errorMessageImage(String path) =>
       "File is not an image or does not exist: $path";
-
+  /// Returns an error message when an outputPath file is neither a PDF nor an image, or does not exist.
+  ///
+  /// - [path] The file path of the invalid or non-existent file.
+  static String errorMessageMixedOutputPath(String path) =>
+      "The outputPath file is neither a PDF document nor an image or does not exist: $path";
   /// Returns an error message when a file is neither a PDF nor an image, or does not exist.
   ///
   /// - [path] The file path of the invalid or non-existent file.

--- a/lib/responses/pdf_combiner_messages.dart
+++ b/lib/responses/pdf_combiner_messages.dart
@@ -26,11 +26,13 @@ class PdfCombinerMessages {
   /// - [path] The file path of the invalid or non-existent image.
   static String errorMessageImage(String path) =>
       "File is not an image or does not exist: $path";
-  /// Returns an error message when an outputPath file is neither a PDF nor an image, or does not exist.
+
+  /// Returns an error message when the outputPath does not have the expected .pdf format.
   ///
-  /// - [path] The file path of the invalid or non-existent file.
-  static String errorMessageMixedOutputPath(String path) =>
-      "The outputPath file is neither a PDF document nor an image or does not exist: $path";
+  /// - [path] The file path that does not meet the expected format.
+  static String errorMessageInvalidOutputPath(String path) =>
+      "The outputPath must have a .pdf format: $path";
+
   /// Returns an error message when a file is neither a PDF nor an image, or does not exist.
   ///
   /// - [path] The file path of the invalid or non-existent file.

--- a/lib/utils/document_utils.dart
+++ b/lib/utils/document_utils.dart
@@ -19,6 +19,9 @@ class DocumentUtils {
       return false;
     }
   }
+  static Future<bool> hasPDFExtension(String filePath) async {
+      return filePath.endsWith(".pdf");
+  }
 
   /// Determines whether the given file path corresponds to an image file.
   ///

--- a/lib/utils/document_utils.dart
+++ b/lib/utils/document_utils.dart
@@ -1,5 +1,6 @@
 import 'package:file_magic_number/file_magic_number.dart';
 import 'package:file_magic_number/file_magic_number_type.dart';
+import 'package:path/path.dart' as p;
 
 /// Utility class for handling document-related checks in a file system environment.
 ///
@@ -19,9 +20,11 @@ class DocumentUtils {
       return false;
     }
   }
-  static Future<bool> hasPDFExtension(String filePath) async {
-      return filePath.endsWith(".pdf");
-  }
+
+  /// Checks if the given file path has a PDF extension.
+  /// Returns `true` if the file has a `.pdf` extension, otherwise `false`.
+  static bool hasPDFExtension(String filePath) =>
+      p.extension(filePath) == ".pdf";
 
   /// Determines whether the given file path corresponds to an image file.
   ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
+  path: ^1.9.1
   plugin_platform_interface: ^2.1.8
   web: ^1.1.0
   file_magic_number: ^1.1.0

--- a/test/pdf_combiner_combine_test.dart
+++ b/test/pdf_combiner_combine_test.dart
@@ -65,6 +65,28 @@ void main() {
           'MergeMultiplePDFResponse{outputPath: ${result.outputPath}, message: ${result.message}, status: ${result.status} }');
     });
 
+    // Test for wrong outputPath in combining multiple PDFs using PdfCombiner.
+    test('mergeMultiplePDFs wrong outputPath', () async {
+      MockPdfCombinerPlatform fakePlatform = MockPdfCombinerPlatform();
+
+      PdfCombinerPlatform.instance = fakePlatform;
+
+      final result = await PdfCombiner.mergeMultiplePDFs(
+        inputPaths: [
+          'example/assets/document_1.pdf',
+          'example/assets/document_2.pdf'
+        ],
+        outputPath: 'output/path.jpeg',
+      );
+
+      expect(result.status, PdfCombinerStatus.error);
+      expect(result.outputPath, "");
+      expect(result.message,
+          'The outputPath must have a .pdf format: output/path.jpeg');
+      expect(result.toString(),
+          'MergeMultiplePDFResponse{outputPath: ${result.outputPath}, message: ${result.message}, status: ${result.status} }');
+    });
+
     // Test for error setting a different type of file in the mergeMultiplePDF method.
     test('combine - Error empty inputPaths', () async {
       // Create a mock platform that simulates an error during PDF merging.

--- a/test/pdf_combiner_combine_test.dart
+++ b/test/pdf_combiner_combine_test.dart
@@ -98,7 +98,7 @@ void main() {
       // Call the method and check the response.
       final result = await PdfCombiner.mergeMultiplePDFs(
         inputPaths: ['path1', 'path2'],
-        outputPath: 'output/path',
+        outputPath: 'output/path.pdf',
       );
 
       // Verify the error result matches the expected values.
@@ -119,7 +119,7 @@ void main() {
 
       final result = await fakePlatformWithError.mergeMultiplePDFs(
         inputPaths: ['path1', 'path2'],
-        outputPath: 'output/path',
+        outputPath: 'output/path.pdf',
       );
 
       // Verify the error result matches the expected values.
@@ -136,7 +136,7 @@ void main() {
       // Call the method and check the response.
       final result = await PdfCombiner.mergeMultiplePDFs(
         inputPaths: ['path1.pdf', 'path2.pdf'],
-        outputPath: 'output/path',
+        outputPath: 'output/path.pdf',
       );
 
       // Verify the error result matches the expected values.
@@ -160,7 +160,7 @@ void main() {
           'example/assets/document_1.pdf',
           'example/assets/document_2.pdf'
         ],
-        outputPath: 'output/path',
+        outputPath: 'output/path.pdf',
       );
 
       // Verify the result matches the expected mock values.
@@ -185,7 +185,7 @@ void main() {
           'example/assets/document_1.pdf',
           'example/assets/document_2.pdf'
         ],
-        outputPath: 'output/path',
+        outputPath: 'output/path.pdf',
       );
 
       // Verify the result matches the expected mock values.
@@ -211,7 +211,7 @@ void main() {
           'example/assets/document_1.pdf',
           'example/assets/document_2.pdf'
         ],
-        outputPath: 'output/path',
+        outputPath: 'output/path.pdf',
       );
 
       // Verify the result matches the expected mock values.

--- a/test/pdf_combiner_create_pdf_from_multiple_images_test.dart
+++ b/test/pdf_combiner_create_pdf_from_multiple_images_test.dart
@@ -21,7 +21,7 @@ void main() {
       // Call the method and check the response.
       final result = await PdfCombiner.createPDFFromMultipleImages(
         inputPaths: [],
-        outputPath: 'output/path',
+        outputPath: 'output/path.pdf',
       );
 
       // Verify the error result matches the expected values.
@@ -41,7 +41,7 @@ void main() {
       // Call the method and check the response.
       final result = await PdfCombiner.createPDFFromMultipleImages(
         inputPaths: ['path1.jpg', 'path2.jpg'],
-        outputPath: 'output/path',
+        outputPath: 'output/path.pdf',
       );
 
       // Verify the error result matches the expected values.
@@ -62,7 +62,7 @@ void main() {
       // Call the method and check the response.
       final result = await PdfCombiner.createPDFFromMultipleImages(
         inputPaths: ['assets/document_1.pdf', 'path2.jpg'],
-        outputPath: 'output/path',
+        outputPath: 'output/path.pdf',
       );
 
       // Verify the error result matches the expected values.
@@ -87,7 +87,7 @@ void main() {
           'example/assets/image_1.jpeg',
           'example/assets/image_2.png'
         ],
-        outputPath: 'output/path',
+        outputPath: 'output/path.pdf',
       );
 
       // Verify the error result matches the expected values.
@@ -134,7 +134,7 @@ void main() {
     // Call the method and check the response.
     final result = await PdfCombiner.createPDFFromMultipleImages(
       inputPaths: ['example/assets/image_1.jpeg', 'example/assets/image_2.png'],
-      outputPath: 'output/path',
+      outputPath: 'output/path.pdf',
     );
 
     // Verify the result matches the expected mock values.
@@ -156,7 +156,7 @@ void main() {
     // Call the method and check the response.
     final result = await PdfCombiner.createPDFFromMultipleImages(
       inputPaths: ['example/assets/image_1.jpeg', 'example/assets/image_2.png'],
-      outputPath: 'output/path',
+      outputPath: 'output/path.pdf',
     );
 
     // Verify the result matches the expected mock values.
@@ -178,7 +178,7 @@ void main() {
     // Call the method and check the response.
     final result = await PdfCombiner.createPDFFromMultipleImages(
       inputPaths: ['example/assets/image_1.jpeg', 'example/assets/image_2.png'],
-      outputPath: 'output/path',
+      outputPath: 'output/path.pdf',
     );
 
     // Verify the result matches the expected mock values.

--- a/test/pdf_combiner_create_pdf_from_multiple_images_test.dart
+++ b/test/pdf_combiner_create_pdf_from_multiple_images_test.dart
@@ -123,6 +123,30 @@ void main() {
     });
   });
 
+  // Test for error handling when you try to send a file that its not a pdf in createPDFFromMultipleImages
+  test('createPDFFromMultipleImages wrong outputPath', () async {
+    MockPdfCombinerPlatform fakePlatform = MockPdfCombinerPlatform();
+
+    // Replace the platform instance with the mock implementation.
+    PdfCombinerPlatform.instance = fakePlatform;
+
+    final outputPath = 'output/path/pdf_output.jpeg';
+
+    // Call the method and check the response.
+    final result = await PdfCombiner.createPDFFromMultipleImages(
+      inputPaths: ['example/assets/image_1.jpeg', 'example/assets/image_2.png'],
+      outputPath: outputPath,
+    );
+
+    // Verify the error result matches the expected values.
+    expect(result.status, PdfCombinerStatus.error);
+    expect(result.outputPath, "");
+    expect(result.message,
+        'The outputPath must have a .pdf format: output/path/pdf_output.jpeg');
+    expect(result.toString(),
+        'PdfFromMultipleImageResponse{outputPath: ${result.outputPath}, message: ${result.message}, status: ${result.status} }');
+  });
+
   // Test for error processing when creating pdf from multiple images using PdfCombiner.
   test('createPDFFromMultipleImages - Mocked Exception', () async {
     MockPdfCombinerPlatformWithException fakePlatform =

--- a/test/pdf_combiner_generate_from_documents_test.dart
+++ b/test/pdf_combiner_generate_from_documents_test.dart
@@ -197,7 +197,7 @@ void main() {
       // Call the method and check the response.
       final result = await PdfCombiner.generatePDFFromDocuments(
         inputPaths: [],
-        outputPath: 'output/path',
+        outputPath: 'output/path.pdf',
       );
 
       // Verify the error result matches the expected values.
@@ -218,7 +218,7 @@ void main() {
       // Call the method and check the response.
       final result = await PdfCombiner.generatePDFFromDocuments(
         inputPaths: ['path1', 'path2'],
-        outputPath: 'output/path',
+        outputPath: 'output/path.pdf',
       );
 
       // Verify the error result matches the expected values.
@@ -238,7 +238,7 @@ void main() {
       // Call the method and check the response.
       final result = await PdfCombiner.generatePDFFromDocuments(
         inputPaths: ['path1.pdf', 'path2.pdf'],
-        outputPath: 'output/path',
+        outputPath: 'output/path.pdf',
       );
 
       // Verify the error result matches the expected values.
@@ -262,7 +262,7 @@ void main() {
           'example/assets/document_1.pdf',
           'example/assets/document_2.pdf'
         ],
-        outputPath: 'output/path',
+        outputPath: 'output/path.pdf',
       );
 
       // Verify the result matches the expected mock values.
@@ -287,7 +287,7 @@ void main() {
           'example/assets/document_1.pdf',
           'example/assets/document_2.pdf'
         ],
-        outputPath: 'output/path',
+        outputPath: 'output/path.pdf',
       );
 
       // Verify the result matches the expected mock values.
@@ -312,7 +312,7 @@ void main() {
         inputPaths: [
           'example/assets/image_1.jpeg',
         ],
-        outputPath: 'output/path',
+        outputPath: 'output/path.pdf',
       );
 
       // Verify the result matches the expected mock values.

--- a/test/pdf_combiner_generate_from_documents_test.dart
+++ b/test/pdf_combiner_generate_from_documents_test.dart
@@ -14,7 +14,7 @@ import 'mocks/mock_pdf_combiner_platform_with_exception.dart';
 void main() {
   group('PdfCombiner Generate From Document Unit Tests', () {
     late File testFile1;
-    final String testFilePath1 = 'output_path.pdf';
+    final String testFilePath1 = 'document_0.pdf';
     PdfCombiner.isMock = true;
 
     setUp(() async {
@@ -78,11 +78,11 @@ void main() {
           'example/assets/image_1.jpeg',
           'example/assets/document_1.pdf',
         ],
-        outputPath: 'output_path.pdf',
+        outputPath: 'path.pdf',
       );
       // Verify the result matches the expected mock values.
       expect(result.status, PdfCombinerStatus.success);
-      expect(result.outputPath, "output_path.pdf");
+      expect(result.outputPath, "path.pdf");
       expect(result.message, 'Processed successfully');
       expect(result.toString(),
           'GeneratePdfFromDocumentsResponse{outputPath: ${result.outputPath}, message: ${result.message}, status: ${result.status} }');
@@ -102,13 +102,13 @@ void main() {
           'example/assets/document_1.pdf',
           'example/assets/image_1.jpeg'
         ],
-        outputPath: 'output-path.pdf',
+        outputPath: 'path.pdf',
       );
       // Verify the result matches the expected mock values.
       expect(result.status, PdfCombinerStatus.error);
       expect(result.outputPath, "");
       expect(result.message,
-          'File is not of PDF type or does not exist: output-path.pdf');
+          'File is not of PDF type or does not exist: ./document_1.pdf');
       expect(result.toString(),
           'GeneratePdfFromDocumentsResponse{outputPath: ${result.outputPath}, message: ${result.message}, status: ${result.status} }');
     });
@@ -127,13 +127,13 @@ void main() {
           'example/assets/document_1.pdf',
           'example/assets/image_1.jpeg'
         ],
-        outputPath: 'output-path.pdf',
+        outputPath: 'path.pdf',
       );
       // Verify the result matches the expected mock values.
       expect(result.status, PdfCombinerStatus.error);
       expect(result.outputPath, "");
       expect(result.message,
-          'File is not of PDF type or does not exist: output-path.pdf');
+          'File is not of PDF type or does not exist: ./document_1.pdf');
       expect(result.toString(),
           'GeneratePdfFromDocumentsResponse{outputPath: ${result.outputPath}, message: ${result.message}, status: ${result.status} }');
     });
@@ -151,13 +151,13 @@ void main() {
           'example/assets/image_1.jpeg',
           'example/assets/image_2.png'
         ],
-        outputPath: 'output-path.pdf',
+        outputPath: 'path.pdf',
       );
       // Verify the result matches the expected mock values.
       expect(result.status, PdfCombinerStatus.error);
       expect(result.outputPath, "");
       expect(result.message,
-          'File is not of PDF type or does not exist: output-path.pdf');
+          'File is not of PDF type or does not exist: ./document_1.pdf');
       expect(result.toString(),
           'GeneratePdfFromDocumentsResponse{outputPath: ${result.outputPath}, message: ${result.message}, status: ${result.status} }');
     });

--- a/test/pdf_combiner_generate_from_documents_test.dart
+++ b/test/pdf_combiner_generate_from_documents_test.dart
@@ -88,6 +88,29 @@ void main() {
           'GeneratePdfFromDocumentsResponse{outputPath: ${result.outputPath}, message: ${result.message}, status: ${result.status} }');
     });
 
+    // Test for error with wrong outputPath in combining multiple PDFs using PdfCombiner.
+    test('error with wrong outputPath (PdfCombiner)', () async {
+      MockPdfCombinerPlatform fakePlatform = MockPdfCombinerPlatform();
+
+      // Replace the platform instance with the mock implementation.
+      PdfCombinerPlatform.instance = fakePlatform;
+
+      // Call the method and check the response.
+      final result = await PdfCombiner.generatePDFFromDocuments(
+        inputPaths: [
+          'example/assets/image_1.jpeg',
+          'example/assets/document_1.pdf',
+        ],
+        outputPath: 'path.jpg',
+      );
+      // Verify the result matches the expected mock values.
+      expect(result.status, PdfCombinerStatus.error);
+      expect(result.outputPath, "");
+      expect(result.message, 'The outputPath must have a .pdf format: path.jpg');
+      expect(result.toString(),
+          'GeneratePdfFromDocumentsResponse{outputPath: ${result.outputPath}, message: ${result.message}, status: ${result.status} }');
+    });
+
     // Test for successfully combining multiple PDFs using PdfCombiner.
     test('generatePDFFromDocuments File does not exist (PdfCombiner)',
         () async {


### PR DESCRIPTION
PDF Creation with Multiple Images: Resolved an issue where attempting to create a PDF with two or more images caused the application to fail, preventing PDF generation. The fix ensures that images are properly processed and combined into a single PDF. Issue: https://github.com/vicajilau/pdf_combiner/issues/40