### PR TITLE
Include ProGuard configuration in plugin to prevent R8 issues with optional JPEG 2000 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.3.3
+### Android
+* Fixed an issue where R8 errors happens during release builds due to missing classes. [#67](https://github.com/vicajilau/pdf_combiner/issues/67)
+
 ## 4.3.2
 ### Android
 * Fixed an issue where multiple PDF files are combined, the resolution of the pages decreases. [#65](https://github.com/vicajilau/pdf_combiner/issues/65)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,6 +47,7 @@ android {
 
     defaultConfig {
         minSdk = 21
+        consumerProguardFiles 'proguard-rules.pro'
     }
 
     dependencies {

--- a/android/proguard-rules.pro
+++ b/android/proguard-rules.pro
@@ -1,0 +1,1 @@
+-dontwarn com.gemalto.jp2.**

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -189,10 +189,10 @@ packages:
     dependency: "direct main"
     description:
       name: file_picker
-      sha256: "182fb2eddd7f917d69424c2ce95da28ed932ee654dbe010c33408884450ce5d2"
+      sha256: a222f231db4f822fc49e3b753674bda630e981873c84bf8604bceeb77fce0b24
       url: "https://pub.dev"
     source: hosted
-    version: "10.1.6"
+    version: "10.1.7"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -509,7 +509,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "4.3.2"
+    version: "4.3.3"
   permission_handler:
     dependency: "direct main"
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   cupertino_icons: ^1.0.8
   desktop_drop: ^0.6.0
   file_magic_number: ^1.3.0
-  file_picker: ^10.1.6
+  file_picker: ^10.1.7
   path_provider: ^2.1.5
   path: ^1.9.0
   permission_handler: ^12.0.0+1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pdf_combiner
 description: "It is a lightweight and efficient Flutter plugin designed to merge multiple PDF documents into a single file effortlessly."
-version: 4.3.2
+version: 4.3.3
 homepage: https://github.com/vicajilau/pdf_combiner
 
 environment:


### PR DESCRIPTION
## Summary

This PR adds a `consumerProguardFiles` directive to the plugin's Android build, including a custom ProGuard rule to prevent release build errors caused by missing optional JPEG 2000 classes (`com.gemalto.jp2.*`) referenced by Apache PDFBox.

## Motivation

After introducing Apache PDFBox to solve the PDF quality degradation issue, users started experiencing R8 errors during release builds due to missing classes like:

```
com.gemalto.jp2.JP2Decoder
com.gemalto.jp2.JP2Encoder
```

These classes are referenced by PDFBox’s `JPXFilter` for optional JPEG 2000 support, but they are not bundled with PDFBox and are not required by this plugin.

To address this, and avoid forcing plugin consumers to modify their `proguard-rules.pro`, this PR configures the necessary ProGuard rules directly in the plugin’s AAR packaging using `consumerProguardFiles`.

## What was changed

* Added a `proguard-gemalto-ignore.pro` file to `android/src/main/resources/META-INF/proguard/`
* Configured the `build.gradle` to include it via `consumerProguardFiles`
* The rule added:

  ```proguard
  -dontwarn com.gemalto.jp2.**
  ```

## Related Issue

Fixes [#67](https://github.com/vicajilau/pdf_combiner/issues/67)

## Benefits

* No need for consumers to modify their app-level ProGuard configuration
* Smooth release builds with R8 minification enabled
* Fully self-contained plugin configuration

## Notes

We do not use JPEG 2000 support in this plugin, so these classes are not required at runtime. If support is needed in the future, a dynamic or optional approach will be considered. @daniJimen just to keep you in post.