### PR TITLE
Refactor: Unified MergeInput Model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ### General
 
+* **BREAKING CHANGE**: `mergeMultiplePDFs` now requires `inputs` parameter (List<MergeInput>) instead of `inputPaths`.
+* **BREAKING CHANGE**: `createPDFFromMultipleImages` now requires `inputs` parameter (List<MergeInput>) instead of `inputPaths`.
+* **BREAKING CHANGE**: `generatePDFFromDocuments` now requires `inputs` parameter (List<MergeInput>) instead of `inputPaths`.
+* **BREAKING CHANGE**: `createImageFromPDF` now requires `input` parameter (MergeInput) instead of `inputPath`.
+* **BREAKING CHANGE**: Removed `inputPaths`/`inputPath` parameter from all methods.
+* Added `MergeInput` class hierarchy (`MergeInputPath`, `MergeInputBytes`) to support combining PDFs from files and raw bytes.
+
+
 * **BREAKING CHANGE**: Removed custom response models (`GeneratePdfFromDocumentsResponse`, `ImageFromPDFResponse`, `MergeMultiplePDFResponse` and `PdfFromMultipleImageResponse`).
 * **BREAKING CHANGE**: Methods now return `Future<String>` (path) or `Future<List<String>>` (paths) directly.
 * **BREAKING CHANGE**: Removed `PdfCombinerStatus` enum and `PdfCombinerDelegate`.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ sudo apt-get install libheif-dev
 ```
 
 ## Features
+### MergeInput
+
+The plugin introduces a unified `MergeInput` class to handle inputs from different sources:
+
+- **`MergeInputPath(String path)`**: Use this when you have the file path (e.g., from `file_picker` or local storage).
+- **`MergeInputBytes(Uint8List bytes)`**: Use this when you have the file data in memory (e.g., from an API or web picker).
 
 ### Create PDF From Multiple Documents
 
@@ -64,23 +70,26 @@ Combine any number of PDFs and images, in any order, into a single PDF document.
 
 **Required Parameters:**
 
-- `inputPaths`: A list of strings representing the image and PDF file paths.
-- `outputPath`: A string representing the absolute path of the file where the generated PDF should be saved. In the case of web, this parameter is ignored. The file extension must be `.pdf`.
+- `inputs`: A list of `MergeInput` objects representing the image and PDF inputs.
+- `outputPath`: A string representing the absolute path where the generated PDF should be saved. (Ignored on Web).
 
 ```dart
-final imagePaths = ["path/to/image1.jpg", "path/to/document1.pdf", "path/to/image2.png"];
+final inputs = [
+  MergeInputPath("path/to/image1.jpg"),
+  MergeInputPath("path/to/document1.pdf"),
+  MergeInputBytes(imageBytes), // Example with bytes
+];
 final outputPath = "path/to/output.pdf";
 
 try {
   String response = await PdfCombiner.generatePDFFromDocuments(
-    inputPaths: imagePaths,
+    inputs: inputs,
     outputPath: outputPath,
   );
 
   print("File saved to: $response");
 
 } catch (e) {
-  // If the error is handled by the plugin, a PdfCombinerException is thrown.
   print("Error: $e");
 }
 ```
@@ -91,21 +100,23 @@ Combine several PDF files into a single document.
 
 **Required Parameters:**
 
-- `inputPaths`: A list of strings representing the paths of the PDF files to combine.
-- `outputPath`: A string representing the absolute path of the file where the combined PDF should be saved. In the case of web, this parameter is ignored. The file extension must be `.pdf`.
+- `inputs`: A list of `MergeInput` objects representing the PDF files to combine.
+- `outputPath`: A string representing the absolute path where the combined PDF should be saved. (Ignored on Web).
 
 ```dart
-final filesPath = ["path/to/file1.pdf", "path/to/file2.pdf"];
+final inputs = [
+  MergeInputPath("path/to/file1.pdf"),
+  MergeInputPath("path/to/file2.pdf"),
+];
 final outputPath = "path/to/output.pdf";
 
 try {
   String response = await PdfCombiner.mergeMultiplePDFs(
-    inputPaths: filesPath,
+    inputs: inputs,
     outputPath: outputPath,
   );
   print("File saved to: $response");
 } catch (e) {
-  // If the error is handled by the plugin, a PdfCombinerException is thrown.
   print("Error: $e");
 }
 ```
@@ -116,25 +127,25 @@ Convert a list of image files into a single PDF document.
 
 **Required Parameters:**
 
-- `inputPaths`: A list of strings representing the image file paths.
-- `outputPath`: A string representing the absolute path of the file where the generated PDF should be saved. In the case of web, this parameter is ignored. The file extension must be `.pdf`.
-
-By default, images are added to the PDF without modifications. If needed, you can customize the scaling, compression, and aspect ratio using a configuration object.
+- `inputs`: A list of `MergeInput` objects representing the images.
+- `outputPath`: A string representing the absolute path where the generated PDF should be saved. (Ignored on Web).
 
 ```dart
-final imagePaths = ["path/to/image1.jpg", "path/to/image2.jpg"];
+final inputs = [
+  MergeInputPath("path/to/image1.jpg"),
+  MergeInputPath("path/to/image2.jpg"),
+];
 final outputPath = "path/to/output.pdf";
 
 try {
   String response = await PdfCombiner.createPDFFromMultipleImages(
-    inputPaths: imagePaths,
+    inputs: inputs,
     outputPath: outputPath,
   );
 
   print("File saved to: $response");
 
 } catch (e) {
-  // If the error is handled by the plugin, a PdfCombinerException is thrown.
   print("Error: $e");
 }
 ```
@@ -151,12 +162,15 @@ The `PdfFromMultipleImageConfig` class is used to configure how images are proce
 Example Usage:
 
 ```dart
-final imagePaths = ["path/to/image1.jpg", "path/to/image2.jpg"];
+final inputs = [
+  MergeInputPath("path/to/image1.jpg"),
+  MergeInputPath("path/to/image2.jpg"),
+];
 final outputPath = "path/to/output.pdf";
 
 try {
   String response = await PdfCombiner.createPDFFromMultipleImages(
-    inputPaths: imagePaths,
+    inputs: inputs,
     outputPath: outputPath,
     config: const PdfFromMultipleImageConfig(
       rescale: ImageScale(width: 480, height: 640),
@@ -166,7 +180,6 @@ try {
   print("File saved to: $response");
 
 } catch (e) {
-  // If the error is handled by the plugin, a PdfCombinerException is thrown.
   print("Error: $e");
 }
 ```
@@ -177,23 +190,20 @@ Extract images from a PDF file.
 
 **Required Parameters:**
 
-- `inputPath`: A string representing the file path of the PDF to extract images from.
-- `outputDirPath`: A string representing the directory folder where the extracted images should be saved. In the case of web, this parameter is ignored.
-
-By default, images are extracted in their original format. If needed, you can customize the scaling, compression, and aspect ratio using a configuration object.
+- `input`: A `MergeInput` object representing the PDF to extract images from.
+- `outputDirPath`: A string representing the directory folder where the extracted images should be saved. (Ignored on Web).
 
 ```dart
-final pdfFilePath = "path/to/input.pdf";
+final input = MergeInputPath("path/to/input.pdf");
 final outputDirPath = "path/to/output";
 
 try {
   List<String> response = await PdfCombiner.createImageFromPDF(
-    inputPath: pdfFilePath, 
+    input: input, 
     outputDirPath: outputDirPath,
   );
   print("Files generated: $response");
 } catch (e) {
-  // If the error is handled by the plugin, a PdfCombinerException is thrown.
   print("Error: $e");
 }
 ```
@@ -211,12 +221,12 @@ The `ImageFromPdfConfig` class is used to configure how images are processed bef
 Example Usage:
 
 ```dart
-final pdfFilePath = "path/to/input.pdf";
+final input = MergeInputPath("path/to/input.pdf");
 final outputDirPath = "path/to/output";
 
 try {
   List<String> response = await PdfCombiner.createImageFromPDF(
-    inputPath: pdfFilePath,
+    input: input,
     outputDirPath: outputDirPath,
     config: const ImageFromPdfConfig(
       rescale: ImageScale(width: 480, height: 640),
@@ -226,7 +236,6 @@ try {
   );
   print("Files generated: $response");
 } catch (e) {
-  // If the error is handled by the plugin, a PdfCombinerException is thrown.
   print("Error: $e");
 }
 ```

--- a/example/integration_test/create_image_from_pdf_integration_test.dart
+++ b/example/integration_test/create_image_from_pdf_integration_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:pdf_combiner/exception/pdf_combiner_exception.dart';
-import 'package:pdf_combiner/models/image_from_pdf_config.dart';
+
 import 'package:pdf_combiner/pdf_combiner.dart';
 
 import 'test_file_helper.dart';
@@ -20,7 +20,7 @@ void main() {
       final outputPath = await helper.getOutputFilePath();
 
       final result = await PdfCombiner.createImageFromPDF(
-        inputPath: inputPaths[0],
+        input: MergeInputPath(inputPaths[0]),
         outputDirPath: outputPath,
       );
 
@@ -35,7 +35,7 @@ void main() {
 
       expect(
         () => PdfCombiner.createImageFromPDF(
-          inputPath: inputPaths[0],
+          input: MergeInputPath(inputPaths[0]),
           outputDirPath: outputPath,
         ),
         throwsA(
@@ -56,7 +56,7 @@ void main() {
 
       expect(
         () => PdfCombiner.createImageFromPDF(
-          inputPath: inputPaths[0],
+          input: MergeInputPath(inputPaths[0]),
           outputDirPath: outputPath,
         ),
         throwsA(
@@ -76,7 +76,7 @@ void main() {
       final outputPath = await helper.getOutputFilePath();
 
       final result = await PdfCombiner.createImageFromPDF(
-          inputPath: inputPaths[0], outputDirPath: outputPath);
+          input: MergeInputPath(inputPaths[0]), outputDirPath: outputPath);
 
       expect(result.length, 1);
       expect(result, ['${TestFileHelper.basePath}/image_1.png']);
@@ -88,7 +88,7 @@ void main() {
       final outputPath = await helper.getOutputFilePath();
 
       final result = await PdfCombiner.createImageFromPDF(
-          inputPath: inputPaths[0],
+          input: MergeInputPath(inputPaths[0]),
           outputDirPath: outputPath,
           config: ImageFromPdfConfig(createOneImage: false));
 

--- a/example/integration_test/create_pdf_from_multiple_images_integration_test.dart
+++ b/example/integration_test/create_pdf_from_multiple_images_integration_test.dart
@@ -20,7 +20,7 @@ void main() {
       final outputPath = await helper.getOutputFilePath('merged_output.pdf');
 
       final result = await PdfCombiner.createPDFFromMultipleImages(
-        inputPaths: inputPaths,
+        inputs: inputPaths.map((p) => MergeInputPath(p)).toList(),
         outputPath: outputPath,
       );
 
@@ -30,14 +30,14 @@ void main() {
     testWidgets('Test creating pdf with empty list', (tester) async {
       expect(
         () => PdfCombiner.createPDFFromMultipleImages(
-          inputPaths: [],
+          inputs: [],
           outputPath: '${TestFileHelper.basePath}/assets/merged_output.pdf',
         ),
         throwsA(
           predicate(
             (e) =>
                 e is PdfCombinerException &&
-                e.message == 'The parameter (inputPaths) cannot be empty',
+                e.message == 'The parameter (inputs) cannot be empty',
           ),
         ),
       );
@@ -51,7 +51,7 @@ void main() {
 
       expect(
         () => PdfCombiner.createPDFFromMultipleImages(
-          inputPaths: inputPaths,
+          inputs: inputPaths.map((p) => MergeInputPath(p)).toList(),
           outputPath: outputPath,
         ),
         throwsA(
@@ -74,7 +74,7 @@ void main() {
 
       expect(
         () => PdfCombiner.createPDFFromMultipleImages(
-          inputPaths: inputPaths,
+          inputs: inputPaths.map((p) => MergeInputPath(p)).toList(),
           outputPath: outputPath,
         ),
         throwsA(

--- a/example/integration_test/heic_test.dart
+++ b/example/integration_test/heic_test.dart
@@ -30,9 +30,8 @@ void main() {
       File(outputPath).deleteSync();
     }
 
-    // Call the plugin
     await PdfCombiner.createPDFFromMultipleImages(
-      inputPaths: [sampleHeicPath],
+      inputs: [MergeInputPath(heicFile.path)],
       outputPath: outputPath,
     );
 

--- a/example/integration_test/merge_multiple_pdfs_integration_test.dart
+++ b/example/integration_test/merge_multiple_pdfs_integration_test.dart
@@ -20,7 +20,7 @@ void main() {
       final outputPath = await helper.getOutputFilePath('merged_output.pdf');
 
       final result = await PdfCombiner.mergeMultiplePDFs(
-        inputPaths: inputPaths,
+        inputs: inputPaths.map((p) => MergeInputPath(p)).toList(),
         outputPath: outputPath,
       );
 
@@ -33,7 +33,7 @@ void main() {
       final outputPath = await helper.getOutputFilePath('merged_output.pdf');
 
       final result = await PdfCombiner.mergeMultiplePDFs(
-        inputPaths: inputPaths,
+        inputs: inputPaths.map((p) => MergeInputPath(p)).toList(),
         outputPath: outputPath,
       );
 
@@ -46,14 +46,14 @@ void main() {
 
       expect(
         () => PdfCombiner.mergeMultiplePDFs(
-          inputPaths: [],
+          inputs: [],
           outputPath: outputPath,
         ),
         throwsA(
           predicate(
             (e) =>
                 e is PdfCombinerException &&
-                e.message == 'The parameter (inputPaths) cannot be empty',
+                e.message == 'The parameter (inputs) cannot be empty',
           ),
         ),
       );
@@ -67,7 +67,7 @@ void main() {
 
       expect(
         () => PdfCombiner.mergeMultiplePDFs(
-          inputPaths: inputPaths,
+          inputs: inputPaths.map((p) => MergeInputPath(p)).toList(),
           outputPath: outputPath,
         ),
         throwsA(
@@ -89,7 +89,7 @@ void main() {
 
       expect(
         () => PdfCombiner.mergeMultiplePDFs(
-          inputPaths: inputPaths,
+          inputs: inputPaths.map((p) => MergeInputPath(p)).toList(),
           outputPath: outputPath,
         ),
         throwsA(

--- a/example/lib/view_models/pdf_combiner_view_model.dart
+++ b/example/lib/view_models/pdf_combiner_view_model.dart
@@ -63,7 +63,7 @@ class PdfCombinerViewModel {
       String outputFilePath = '${directory?.path}/combined_output.pdf';
 
       final response = await PdfCombiner.mergeMultiplePDFs(
-        inputPaths: selectedFiles,
+        inputs: selectedFiles.map((p) => MergeInputPath(p)).toList(),
         outputPath: outputFilePath,
       ); // Combine the PDFs
       outputFiles = [response];
@@ -76,7 +76,7 @@ class PdfCombinerViewModel {
     final directory = await _getOutputDirectory();
     String outputFilePath = '${directory?.path}/combined_output.pdf';
     final response = await PdfCombiner.createPDFFromMultipleImages(
-      inputPaths: selectedFiles,
+      inputs: selectedFiles.map((p) => MergeInputPath(p)).toList(),
       outputPath: outputFilePath,
     );
     outputFiles = [response];
@@ -88,7 +88,7 @@ class PdfCombinerViewModel {
     final directory = await _getOutputDirectory();
     String outputFilePath = '${directory?.path}/combined_output.pdf';
     final response = await PdfCombiner.generatePDFFromDocuments(
-      inputPaths: selectedFiles,
+      inputs: selectedFiles.map((p) => MergeInputPath(p)).toList(),
       outputPath: outputFilePath,
     );
     outputFiles = [response];
@@ -103,8 +103,11 @@ class PdfCombinerViewModel {
     final directory = await _getOutputDirectory();
     final outputFilePath = '${directory?.path}';
     final response = await PdfCombiner.createImageFromPDF(
-      inputPath: selectedFiles.first,
+      input: MergeInputPath(selectedFiles.first),
       outputDirPath: outputFilePath,
+      config: const ImageFromPdfConfig(
+        createOneImage: false,
+      ),
     );
     outputFiles = response;
     return response.toString();

--- a/lib/isolates/images_from_pdf_isolate.dart
+++ b/lib/isolates/images_from_pdf_isolate.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
-import 'package:pdf_combiner/models/image_from_pdf_config.dart';
 import 'package:pdf_combiner/pdf_combiner.dart';
 
 import '../communication/pdf_combiner_platform_interface.dart';

--- a/lib/isolates/pdf_from_multiple_images_isolate.dart
+++ b/lib/isolates/pdf_from_multiple_images_isolate.dart
@@ -5,7 +5,6 @@ import 'package:flutter/services.dart';
 import 'package:pdf_combiner/pdf_combiner.dart';
 
 import '../communication/pdf_combiner_platform_interface.dart';
-import '../models/pdf_from_multiple_image_config.dart';
 
 /// Internal class for handling PDF creation from multiple images using isolates.
 ///

--- a/lib/models/merge_input.dart
+++ b/lib/models/merge_input.dart
@@ -1,0 +1,59 @@
+import 'dart:typed_data';
+
+/// A unified model representing an input for PDF operations.
+///
+/// This abstract base class serves as a polymorphic wrapper for different types
+/// of inputs that can be processed by the [PdfCombiner], such as file paths
+/// or raw byte data.
+///
+/// By using [MergeInput], the API provides a consistent interface regardless
+/// of the underlying data source, allowing for greater flexibility and type safety.
+///
+/// See also:
+/// * [MergeInputPath] for inputs based on file system paths.
+/// * [MergeInputBytes] for inputs based on in-memory byte arrays.
+abstract class MergeInput {
+  /// Constant constructor to allow subclass constructors to be constant.
+  const MergeInput();
+}
+
+/// A generic input type representing a file path.
+///
+/// This class is used when the source document (PDF or image) exists as a file
+/// on the local device's storage. It wraps the absolute path to the file.
+///
+/// Example:
+/// ```dart
+/// final input = MergeInputPath('/storage/emulated/0/Download/document.pdf');
+/// ```
+///
+/// **Note:** Ensure that the path is valid and accessible by the application.
+class MergeInputPath extends MergeInput {
+  /// The absolute file path to the input document.
+  final String path;
+
+  /// Creates a new [MergeInputPath] instance with the specified [path].
+  const MergeInputPath(this.path);
+}
+
+/// A generic input type representing raw byte data.
+///
+/// This class is useful when the document data is available in memory, for example,
+/// downloaded from a network request, generated dynamically, or selected from
+/// a platform picker that returns bytes instead of a path (e.g., on Web).
+///
+/// The [bytes] are expected to be the raw content of a valid PDF or image file
+/// (e.g., PNG, JPEG).
+///
+/// Example:
+/// ```dart
+/// final Uint8List data = ...; // Bytes from API or file picker
+/// final input = MergeInputBytes(data);
+/// ```
+class MergeInputBytes extends MergeInput {
+  /// The raw byte data of the document (PDF or Image).
+  final Uint8List bytes;
+
+  /// Creates a new [MergeInputBytes] instance with the specified [bytes].
+  const MergeInputBytes(this.bytes);
+}

--- a/test/merge_input_test.dart
+++ b/test/merge_input_test.dart
@@ -1,0 +1,26 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_combiner/models/merge_input.dart';
+
+void main() {
+  group('MergeInput Tests', () {
+    test('MergeInputPath stores path correctly', () {
+      const path = '/path/to/file.pdf';
+      final input = MergeInputPath(path);
+      expect(input.path, path);
+    });
+
+    test('MergeInputBytes stores bytes correctly', () {
+      final bytes = Uint8List.fromList([1, 2, 3]);
+      final input = MergeInputBytes(bytes);
+      expect(input.bytes, bytes);
+    });
+
+    // Note: DocumentUtils.prepareInput logic for IO involves file creation,
+    // which relies on getTemporaryDirectory (via path_provider) and file access.
+    // DocumentUtils implementation in the plugin uses conditional imports.
+    // Testing the exact file creation in unit tests might require robust mocking of path_provider
+    // or integration tests. Here we verify the model behavior primarily.
+  });
+}

--- a/test/mocks/mock_pdf_combiner_platform.dart
+++ b/test/mocks/mock_pdf_combiner_platform.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'package:pdf_combiner/communication/pdf_combiner_platform_interface.dart';
 import 'package:pdf_combiner/models/image_from_pdf_config.dart';
 import 'package:pdf_combiner/models/pdf_from_multiple_image_config.dart';
@@ -38,7 +39,10 @@ class MockPdfCombinerPlatform
     required List<String> inputPaths,
     required String outputPath,
     PdfFromMultipleImageConfig config = const PdfFromMultipleImageConfig(),
-  }) {
+  }) async {
+    final file = File(outputPath);
+    await file.create(recursive: true);
+    await file.writeAsBytes([0x25, 0x50, 0x44, 0x46]); // %PDF
     return Future.value(outputPath);
   }
 

--- a/test/pdf_combiner_combine_test.dart
+++ b/test/pdf_combiner_combine_test.dart
@@ -1,10 +1,13 @@
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pdf_combiner/communication/pdf_combiner_method_channel.dart';
 import 'package:pdf_combiner/communication/pdf_combiner_platform_interface.dart';
 import 'package:pdf_combiner/exception/pdf_combiner_exception.dart';
 import 'package:pdf_combiner/pdf_combiner.dart';
+
+import 'package:pdf_combiner/utils/document_utils.dart';
 
 import 'mocks/mock_pdf_combiner_platform.dart';
 import 'mocks/mock_pdf_combiner_platform_with_error.dart';
@@ -21,6 +24,7 @@ void main() {
     setUp(() async {
       testFile1 = File(testFilePath1);
       testFile2 = File(testFilePath2);
+      DocumentUtils.setTemporalFolderPath("./example/assets/temp");
     });
 
     tearDown(() async {
@@ -50,9 +54,45 @@ void main() {
 
       // Call the method and check the response.
       final result = await PdfCombiner.mergeMultiplePDFs(
-        inputPaths: [
-          'example/assets/document_1.pdf',
-          'example/assets/document_2.pdf'
+        inputs: [
+          MergeInputPath('example/assets/document_1.pdf'),
+          MergeInputPath('example/assets/document_2.pdf'),
+        ],
+        outputPath: 'output/path.pdf',
+      );
+
+      // Verify the result matches the expected mock values.
+      expect(result, "output/path.pdf");
+    });
+
+    // Test for combining multiple PDFs using MergeInputBytes.
+    test('combine (MergeInputBytes)', () async {
+      MockPdfCombinerPlatform fakePlatform = MockPdfCombinerPlatform();
+      PdfCombinerPlatform.instance = fakePlatform;
+
+      // Call the method and check the response.
+      final result = await PdfCombiner.mergeMultiplePDFs(
+        inputs: [
+          MergeInputBytes(Uint8List.fromList([0x25, 0x50, 0x44, 0x46])),
+          MergeInputBytes(Uint8List.fromList([0x25, 0x50, 0x44, 0x46])),
+        ],
+        outputPath: 'output/path.pdf',
+      );
+
+      // Verify the result matches the expected mock values.
+      expect(result, "output/path.pdf");
+    });
+
+    // Test for combining mixed MergeInput types.
+    test('combine (Mixed Inputs)', () async {
+      MockPdfCombinerPlatform fakePlatform = MockPdfCombinerPlatform();
+      PdfCombinerPlatform.instance = fakePlatform;
+
+      // Call the method and check the response.
+      final result = await PdfCombiner.mergeMultiplePDFs(
+        inputs: [
+          MergeInputPath('example/assets/document_1.pdf'),
+          MergeInputBytes(Uint8List.fromList([0x25, 0x50, 0x44, 0x46])),
         ],
         outputPath: 'output/path.pdf',
       );
@@ -69,9 +109,9 @@ void main() {
 
       expect(
         () => PdfCombiner.mergeMultiplePDFs(
-          inputPaths: [
-            'example/assets/document_1.pdf',
-            'example/assets/document_2.pdf',
+          inputs: [
+            MergeInputPath('example/assets/document_1.pdf'),
+            MergeInputPath('example/assets/document_2.pdf'),
           ],
           outputPath: 'output/path.jpeg',
         ),
@@ -93,14 +133,14 @@ void main() {
 
       expect(
         () => PdfCombiner.mergeMultiplePDFs(
-          inputPaths: [],
+          inputs: [],
           outputPath: 'output/path',
         ),
         throwsA(
           predicate(
             (e) =>
                 e is PdfCombinerException &&
-                e.message == 'The parameter (inputPaths) cannot be empty',
+                e.message == 'The parameter (inputs) cannot be empty',
           ),
         ),
       );
@@ -113,7 +153,7 @@ void main() {
 
       expect(
         () => PdfCombiner.mergeMultiplePDFs(
-          inputPaths: ['path1', 'path2'],
+          inputs: [MergeInputPath('path1'), MergeInputPath('path2')],
           outputPath: 'output/path.pdf',
         ),
         throwsA(
@@ -149,7 +189,7 @@ void main() {
 
       expect(
         () => PdfCombiner.mergeMultiplePDFs(
-          inputPaths: ['path1.pdf', 'path2.pdf'],
+          inputs: [MergeInputPath('path1.pdf'), MergeInputPath('path2.pdf')],
           outputPath: 'output/path.pdf',
         ),
         throwsA(
@@ -170,9 +210,9 @@ void main() {
 
       expect(
         () => PdfCombiner.mergeMultiplePDFs(
-          inputPaths: [
-            'example/assets/document_1.pdf',
-            'example/assets/document_2.pdf'
+          inputs: [
+            MergeInputPath('example/assets/document_1.pdf'),
+            MergeInputPath('example/assets/document_2.pdf'),
           ],
           outputPath: 'output/path.pdf',
         ),
@@ -191,9 +231,9 @@ void main() {
 
       expect(
         () => PdfCombiner.mergeMultiplePDFs(
-          inputPaths: [
-            'example/assets/document_1.pdf',
-            'example/assets/document_2.pdf'
+          inputs: [
+            MergeInputPath('example/assets/document_1.pdf'),
+            MergeInputPath('example/assets/document_2.pdf'),
           ],
           outputPath: 'output/path.pdf',
         ),
@@ -212,9 +252,9 @@ void main() {
 
       expect(
         () => PdfCombiner.mergeMultiplePDFs(
-          inputPaths: [
-            'example/assets/document_1.pdf',
-            'example/assets/document_2.pdf'
+          inputs: [
+            MergeInputPath('example/assets/document_1.pdf'),
+            MergeInputPath('example/assets/document_2.pdf'),
           ],
           outputPath: 'output/path.pdf',
         ),
@@ -235,9 +275,9 @@ void main() {
 
       expect(
         () => PdfCombiner.mergeMultiplePDFs(
-          inputPaths: [
-            'example/assets/document_1.pdf',
-            'example/assets/document_2.pdf'
+          inputs: [
+            MergeInputPath('example/assets/document_1.pdf'),
+            MergeInputPath('example/assets/document_2.pdf'),
           ],
           outputPath: 'output/path.pdf',
         ),

--- a/test/pdf_combiner_create_images_from_pdf_test.dart
+++ b/test/pdf_combiner_create_images_from_pdf_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pdf_combiner/communication/pdf_combiner_platform_interface.dart';
 import 'package:pdf_combiner/exception/pdf_combiner_exception.dart';
-import 'package:pdf_combiner/models/image_from_pdf_config.dart';
 import 'package:pdf_combiner/models/image_scale.dart';
 import 'package:pdf_combiner/pdf_combiner.dart';
 
@@ -22,7 +21,7 @@ void main() {
       // Call the method and check the response.
       expect(
         () => PdfCombiner.createImageFromPDF(
-          inputPath: 'assets/test_image1.png',
+          input: MergeInputPath('assets/test_image1.png'),
           outputDirPath: 'output/path',
         ),
         throwsA(
@@ -45,7 +44,7 @@ void main() {
 
       expect(
         () => PdfCombiner.createImageFromPDF(
-          inputPath: 'assets/test_image_not_exist.pdf',
+          input: MergeInputPath('assets/test_image_not_exist.pdf'),
           outputDirPath: 'output/path',
         ),
         throwsA(
@@ -67,14 +66,14 @@ void main() {
 
       expect(
         () => PdfCombiner.createImageFromPDF(
-          inputPath: '',
-          outputDirPath: 'output/path',
+          input: MergeInputPath(''),
+          outputDirPath: 'output',
         ),
         throwsA(
           predicate(
             (e) =>
                 e is PdfCombinerException &&
-                e.message == 'The parameter (inputPath) cannot be empty',
+                e.message == 'The parameter (input) cannot be empty',
           ),
         ),
       );
@@ -89,7 +88,7 @@ void main() {
 
       expect(
         () => PdfCombiner.createImageFromPDF(
-          inputPath: 'example/assets/document_1.pdf',
+          input: MergeInputPath('example/assets/document_1.pdf'),
           outputDirPath: 'output/path',
         ),
         throwsA(
@@ -109,7 +108,7 @@ void main() {
 
       expect(
         () => PdfCombiner.createImageFromPDF(
-          inputPath: 'example/assets/document_1.pdf',
+          input: MergeInputPath('example/assets/document_1.pdf'),
           outputDirPath: 'output/path',
         ),
         throwsA(
@@ -129,7 +128,7 @@ void main() {
 
       expect(
         () => PdfCombiner.createImageFromPDF(
-          inputPath: 'example/assets/document_1.pdf',
+          input: MergeInputPath('example/assets/document_1.pdf'),
           outputDirPath: 'output/path',
           config: ImageFromPdfConfig(
             rescale: ImageScale(width: 500, height: 200),
@@ -153,7 +152,7 @@ void main() {
 
       expect(
         () => PdfCombiner.createImageFromPDF(
-          inputPath: 'example/assets/document_1.pdf',
+          input: MergeInputPath('example/assets/document_1.pdf'),
           outputDirPath: 'output/path',
         ),
         throwsA(
@@ -175,7 +174,7 @@ void main() {
 
       // Call the method and check the response.
       final result = await PdfCombiner.createImageFromPDF(
-        inputPath: 'example/assets/document_1.pdf',
+        input: MergeInputPath('example/assets/document_1.pdf'),
         outputDirPath: outputDirPath,
         config: ImageFromPdfConfig(createOneImage: true),
       );
@@ -195,7 +194,7 @@ void main() {
 
       // Call the method and check the response.
       final result = await PdfCombiner.createImageFromPDF(
-        inputPath: 'example/assets/document_1.pdf',
+        input: MergeInputPath('example/assets/document_1.pdf'),
         outputDirPath: outputDirPath,
       );
 

--- a/test/pdf_combiner_create_pdf_from_multiple_images_test.dart
+++ b/test/pdf_combiner_create_pdf_from_multiple_images_test.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pdf_combiner/communication/pdf_combiner_platform_interface.dart';
 import 'package:pdf_combiner/exception/pdf_combiner_exception.dart';
@@ -19,14 +20,14 @@ void main() {
 
       expect(
         () => PdfCombiner.createPDFFromMultipleImages(
-          inputPaths: [],
+          inputs: [],
           outputPath: 'output/path.pdf',
         ),
         throwsA(
           predicate(
             (e) =>
                 e is PdfCombinerException &&
-                e.message == 'The parameter (inputPaths) cannot be empty',
+                e.message == 'The parameter (inputs) cannot be empty',
           ),
         ),
       );
@@ -39,15 +40,14 @@ void main() {
 
       expect(
         () => PdfCombiner.createPDFFromMultipleImages(
-          inputPaths: ['path1.jpg', 'path2.jpg'],
+          inputs: [MergeInputPath('path1'), MergeInputPath('path2')],
           outputPath: 'output/path.pdf',
         ),
         throwsA(
           predicate(
             (e) =>
                 e is PdfCombinerException &&
-                e.message ==
-                    'File is not an image or does not exist: path1.jpg',
+                e.message == 'File is not an image or does not exist: path1',
           ),
         ),
       );
@@ -60,7 +60,10 @@ void main() {
 
       expect(
         () => PdfCombiner.createPDFFromMultipleImages(
-          inputPaths: ['assets/document_1.pdf', 'path2.jpg'],
+          inputs: [
+            MergeInputPath('assets/document_1.pdf'),
+            MergeInputPath('path2.jpg')
+          ],
           outputPath: 'output/path.pdf',
         ),
         throwsA(
@@ -82,9 +85,9 @@ void main() {
 
       expect(
         () => PdfCombiner.createPDFFromMultipleImages(
-          inputPaths: [
-            'example/assets/image_1.jpeg',
-            'example/assets/image_2.png'
+          inputs: [
+            MergeInputPath('example/assets/image_1.jpeg'),
+            MergeInputPath('example/assets/image_2.png')
           ],
           outputPath: 'output/path.pdf',
         ),
@@ -99,23 +102,27 @@ void main() {
     // Test for success process in createPDFFromMultipleImages
     test('createPDFFromMultipleImages - success generate PDF', () async {
       MockPdfCombinerPlatform fakePlatform = MockPdfCombinerPlatform();
-
-      // Replace the platform instance with the mock implementation.
       PdfCombinerPlatform.instance = fakePlatform;
+
+      final image1 = File('image_1.png');
+      await image1
+          .writeAsBytes([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]);
+      final image2 = File('image_2.jpg');
+      await image2.writeAsBytes([0xFF, 0xD8, 0xFF]);
 
       final outputPath = 'output/path/pdf_output.pdf';
 
-      // Call the method and check the response.
-      final result = await PdfCombiner.createPDFFromMultipleImages(
-        inputPaths: [
-          'example/assets/image_1.jpeg',
-          'example/assets/image_2.png'
-        ],
-        outputPath: outputPath,
-      );
+      try {
+        final result = await PdfCombiner.createPDFFromMultipleImages(
+          inputs: [MergeInputPath(image1.path), MergeInputPath(image2.path)],
+          outputPath: outputPath,
+        );
 
-      // Verify the error result matches the expected values.
-      expect(result, outputPath);
+        expect(result, outputPath);
+      } finally {
+        if (await image1.exists()) await image1.delete();
+        if (await image2.exists()) await image2.delete();
+      }
     });
 
     // Test for error handling when you try to send a file that its not a pdf in createPDFFromMultipleImages
@@ -128,9 +135,9 @@ void main() {
 
       expect(
         () => PdfCombiner.createPDFFromMultipleImages(
-          inputPaths: [
-            'example/assets/image_1.jpeg',
-            'example/assets/image_2.png'
+          inputs: [
+            MergeInputPath('example/assets/image_1.jpeg'),
+            MergeInputPath('example/assets/image_2.png')
           ],
           outputPath: outputPath,
         ),
@@ -152,9 +159,9 @@ void main() {
 
       expect(
         () => PdfCombiner.createPDFFromMultipleImages(
-          inputPaths: [
-            'example/assets/image_1.jpeg',
-            'example/assets/image_2.png'
+          inputs: [
+            MergeInputPath('example/assets/image_1.jpeg'),
+            MergeInputPath('example/assets/image_2.png')
           ],
           outputPath: 'output/path.pdf',
         ),
@@ -173,9 +180,9 @@ void main() {
 
       expect(
         () => PdfCombiner.createPDFFromMultipleImages(
-          inputPaths: [
-            'example/assets/image_1.jpeg',
-            'example/assets/image_2.png'
+          inputs: [
+            MergeInputPath('example/assets/image_1.jpeg'),
+            MergeInputPath('example/assets/image_2.png')
           ],
           outputPath: 'output/path.pdf',
         ),
@@ -194,9 +201,9 @@ void main() {
 
       expect(
         () => PdfCombiner.createPDFFromMultipleImages(
-          inputPaths: [
-            'example/assets/image_1.jpeg',
-            'example/assets/image_2.png'
+          inputs: [
+            MergeInputPath('example/assets/image_1.jpeg'),
+            MergeInputPath('example/assets/image_2.png')
           ],
           outputPath: 'output/path.pdf',
         ),

--- a/test/pdf_combiner_from_documents_test.dart
+++ b/test/pdf_combiner_from_documents_test.dart
@@ -10,7 +10,7 @@ void main() {
 
       expect(
         () => PdfCombiner.generatePDFFromDocuments(
-          inputPaths: const [],
+          inputs: [],
           outputPath: 'out.pdf',
         ),
         throwsA(
@@ -18,7 +18,7 @@ void main() {
             (e) =>
                 e is PdfCombinerException &&
                 e.message.contains(
-                  PdfCombinerMessages.emptyParameterMessage('inputPaths'),
+                  PdfCombinerMessages.emptyParameterMessage('inputs'),
                 ),
           ),
         ),
@@ -30,7 +30,7 @@ void main() {
 
       expect(
         () => PdfCombiner.generatePDFFromDocuments(
-          inputPaths: const ['any'],
+          inputs: const [MergeInputPath('any')],
           outputPath: '   ',
         ),
         throwsA(
@@ -51,7 +51,7 @@ void main() {
 
       expect(
         () => PdfCombiner.generatePDFFromDocuments(
-          inputPaths: const ['foo.xyz'],
+          inputs: const [MergeInputPath('foo.xyz')],
           outputPath: 'out.PDF',
         ),
         throwsA(
@@ -72,7 +72,7 @@ void main() {
 
       expect(
         () => PdfCombiner.generatePDFFromDocuments(
-          inputPaths: [firstPath],
+          inputs: [MergeInputPath(firstPath)],
           outputPath: 'out.pdf',
         ),
         throwsA(

--- a/test/pdf_combiner_generate_from_documents_test.dart
+++ b/test/pdf_combiner_generate_from_documents_test.dart
@@ -51,9 +51,9 @@ void main() {
 
       // Call the method and check the response.
       final result = await PdfCombiner.generatePDFFromDocuments(
-        inputPaths: [
-          'example/assets/document_1.pdf',
-          'example/assets/document_2.pdf'
+        inputs: [
+          MergeInputPath('example/assets/document_1.pdf'),
+          MergeInputPath('example/assets/document_2.pdf')
         ],
         outputPath: 'output/path.pdf',
       );
@@ -73,9 +73,9 @@ void main() {
 
       // Call the method and check the response.
       final result = await PdfCombiner.generatePDFFromDocuments(
-        inputPaths: [
-          'example/assets/image_1.jpeg',
-          'example/assets/document_1.pdf',
+        inputs: [
+          MergeInputPath('example/assets/image_1.jpeg'),
+          MergeInputPath('example/assets/document_1.pdf'),
         ],
         outputPath: 'path.pdf',
       );
@@ -92,9 +92,9 @@ void main() {
 
       expect(
         () => PdfCombiner.generatePDFFromDocuments(
-          inputPaths: [
-            'example/assets/image_1.jpeg',
-            'example/assets/document_1.pdf',
+          inputs: [
+            MergeInputPath('example/assets/image_1.jpeg'),
+            MergeInputPath('example/assets/document_1.pdf'),
           ],
           outputPath: 'path.jpg',
         ),
@@ -115,9 +115,9 @@ void main() {
 
       expect(
         () => PdfCombiner.generatePDFFromDocuments(
-          inputPaths: [
-            'example/assets/document_5.pdf',
-            'example/assets/image_1.jpeg'
+          inputs: [
+            MergeInputPath('example/assets/document_5.pdf'),
+            MergeInputPath('example/assets/image_1.jpeg')
           ],
           outputPath: 'path.pdf',
         ),
@@ -139,9 +139,9 @@ void main() {
 
       expect(
         () => PdfCombiner.generatePDFFromDocuments(
-          inputPaths: [
-            'example/assets/document_5.pdf',
-            'example/assets/image_1.jpeg'
+          inputs: [
+            MergeInputPath('example/assets/document_5.pdf'),
+            MergeInputPath('example/assets/image_1.jpeg')
           ],
           outputPath: 'path.pdf',
         ),
@@ -162,9 +162,9 @@ void main() {
 
       expect(
         () => PdfCombiner.generatePDFFromDocuments(
-          inputPaths: [
-            'example/assets/image_5.jpeg',
-            'example/assets/image_2.png'
+          inputs: [
+            MergeInputPath('example/assets/image_5.jpeg'),
+            MergeInputPath('example/assets/image_2.png')
           ],
           outputPath: 'path.pdf',
         ),
@@ -187,9 +187,9 @@ void main() {
 
       expect(
         () => PdfCombiner.generatePDFFromDocuments(
-          inputPaths: [
-            'example/assets/document_1.pdf',
-            'example/assets/image_1.jpeg'
+          inputs: [
+            MergeInputPath('example/assets/document_1.pdf'),
+            MergeInputPath('example/assets/image_1.jpeg')
           ],
           outputPath: '',
         ),
@@ -210,14 +210,14 @@ void main() {
 
       expect(
         () => PdfCombiner.generatePDFFromDocuments(
-          inputPaths: [],
+          inputs: [],
           outputPath: 'output/path.pdf',
         ),
         throwsA(
           predicate(
             (e) =>
                 e is PdfCombinerException &&
-                e.message == 'The parameter (inputPaths) cannot be empty',
+                e.message == 'The parameter (inputs) cannot be empty',
           ),
         ),
       );
@@ -230,7 +230,10 @@ void main() {
 
       expect(
         () => PdfCombiner.generatePDFFromDocuments(
-          inputPaths: ['path1', 'path2'],
+          inputs: [
+            MergeInputPath('path1'),
+            MergeInputPath('path2'),
+          ],
           outputPath: 'output/path.pdf',
         ),
         throwsA(
@@ -250,7 +253,10 @@ void main() {
 
       expect(
         () => PdfCombiner.generatePDFFromDocuments(
-          inputPaths: ['path1.pdf', 'path2.pdf'],
+          inputs: [
+            MergeInputPath('path1.pdf'),
+            MergeInputPath('path2.pdf'),
+          ],
           outputPath: 'output/path.pdf',
         ),
         throwsA(
@@ -271,9 +277,9 @@ void main() {
 
       expect(
         () => PdfCombiner.generatePDFFromDocuments(
-          inputPaths: [
-            'example/assets/document_1.pdf',
-            'example/assets/document_2.pdf'
+          inputs: [
+            MergeInputPath('example/assets/document_1.pdf'),
+            MergeInputPath('example/assets/document_2.pdf')
           ],
           outputPath: 'output/path.pdf',
         ),
@@ -292,9 +298,9 @@ void main() {
 
       expect(
         () => PdfCombiner.generatePDFFromDocuments(
-          inputPaths: [
-            'example/assets/document_1.pdf',
-            'example/assets/document_2.pdf'
+          inputs: [
+            MergeInputPath('example/assets/document_1.pdf'),
+            MergeInputPath('example/assets/document_2.pdf')
           ],
           outputPath: 'output/path.pdf',
         ),
@@ -313,8 +319,8 @@ void main() {
 
       expect(
         () => PdfCombiner.generatePDFFromDocuments(
-          inputPaths: [
-            'example/assets/image_1.jpeg',
+          inputs: [
+            MergeInputPath('example/assets/image_1.jpeg'),
           ],
           outputPath: 'output/path.pdf',
         ),

--- a/test/test_pdf_combiner.dart
+++ b/test/test_pdf_combiner.dart
@@ -19,7 +19,7 @@ void main() {
       });
       DocumentUtils.setTemporalFolderPath("./example/assets/temp");
       var result = await PdfCombiner.generatePDFFromDocuments(
-        inputPaths: ["./example/assets/image_1.jpeg"],
+        inputs: [MergeInputPath("./example/assets/image_1.jpeg")],
         outputPath: "./example/assets/temp/document_0.pdf",
       );
       expect(result, "./example/assets/temp/document_0.pdf");


### PR DESCRIPTION
This PR refactors the PdfCombiner API to use a unified MergeInput model, supporting both file paths and byte arrays. It also updates all tests and documentation. Fixes #98.