### PR TITLE
Feature/merge pdfs refactor code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 * **BREAKING CHANGE**: `mergeMultiplePDFs` parameter changed from `inputPaths: List<String>` to `inputs: List<MergeInput>`.
 * **BREAKING CHANGE**: `createPDFFromMultipleImages` parameter changed from `inputPaths: List<String>` to `inputs: List<MergeInput>`.
 * **BREAKING CHANGE**: `createImageFromPDF` parameter changed from `inputPath: String` to `input: MergeInput`.
-* Added `MergeInput` class with two factory constructors: `MergeInput.path(String)` and `MergeInput.bytes(Uint8List)`.
+* Added `MergeInput` support through explicit input classes for paths and bytes.
 * Added support for mixing file paths and bytes in the same operation.
 * Added support for .heic file format.
 

--- a/README.md
+++ b/README.md
@@ -60,19 +60,19 @@ sudo apt-get install libheif-dev
 
 ### MergeInput
 
-The `MergeInput` class represents an input for PDF operations. It can be created from a file path or from raw bytes (Uint8List).
+`MergeInput` represents an input for PDF operations through explicit subtypes: `MergeInputPath`, `MergeInputBytes`, and `MergeInputUrl`.
 
 **Creating from a file path:**
 
 ```dart
-final input = MergeInput.path("path/to/file.pdf");
+final input = MergeInputPath("path/to/file.pdf");
 ```
 
 **Creating from bytes:**
 
 ```dart
 final Uint8List fileBytes = await getFileBytes(); // Your method to get bytes
-final input = MergeInput.bytes(fileBytes);
+final input = MergeInputBytes(fileBytes);
 ```
 
 **Mixing paths and bytes:**
@@ -81,9 +81,9 @@ You can mix both approaches in the same list, allowing you to combine files from
 
 ```dart
 final inputs = [
-  MergeInput.path("path/to/local_file.pdf"),
-  MergeInput.bytes(fileBytes),
-  MergeInput.path("path/to/another_file.pdf"),
+  MergeInputPath("path/to/local_file.pdf"),
+  MergeInputBytes(fileBytes),
+  MergeInputPath("path/to/another_file.pdf"),
 ];
 ```
 
@@ -102,9 +102,9 @@ Combine any number of PDFs and images, in any order, into a single PDF document.
 final Uint8List fileBytes = await getFileBytes();
 
 final inputs = [
-  MergeInput.path("path/to/local_image.jpg"),
-  MergeInput.bytes(fileBytes),
-  MergeInput.path("path/to/local_document.pdf"),
+  MergeInputPath("path/to/local_image.jpg"),
+  MergeInputBytes(fileBytes),
+  MergeInputPath("path/to/local_document.pdf"),
 ];
 final outputPath = "path/to/output.pdf";
 
@@ -135,9 +135,9 @@ Combine several PDF files into a single document.
 final Uint8List fileBytes = await getFileBytes();
 
 final inputs = [
-  MergeInput.path("path/to/local_file1.pdf"),
-  MergeInput.bytes(fileBytes),
-  MergeInput.path("path/to/local_file2.pdf"),
+  MergeInputPath("path/to/local_file1.pdf"),
+  MergeInputBytes(fileBytes),
+  MergeInputPath("path/to/local_file2.pdf"),
 ];
 final outputPath = "path/to/output.pdf";
 
@@ -168,9 +168,9 @@ By default, images are added to the PDF without modifications. If needed, you ca
 final Uint8List fileBytes = await getFileBytes();
 
 final inputs = [
-  MergeInput.path("path/to/local_image1.jpg"),
-  MergeInput.bytes(fileBytes),
-  MergeInput.path("path/to/local_image2.png"),
+  MergeInputPath("path/to/local_image1.jpg"),
+  MergeInputBytes(fileBytes),
+  MergeInputPath("path/to/local_image2.png"),
 ];
 final outputPath = "path/to/output.pdf";
 
@@ -201,8 +201,8 @@ Example Usage:
 
 ```dart
 final inputs = [
-  MergeInput.path("path/to/image1.jpg"),
-  MergeInput.path("path/to/image2.jpg"),
+  MergeInputPath("path/to/image1.jpg"),
+  MergeInputPath("path/to/image2.jpg"),
 ];
 final outputPath = "path/to/output.pdf";
 
@@ -235,8 +235,8 @@ Extract images from a PDF file.
 By default, images are extracted in their original format. If needed, you can customize the scaling, compression, and aspect ratio using a configuration object.
 
 ```dart
-final input = MergeInput.path("path/to/input.pdf");
-// Or from bytes: final input = MergeInput.bytes(fileBytes);
+final input = MergeInputPath("path/to/input.pdf");
+// Or from bytes: final input = MergeInputBytes(fileBytes);
 final outputDirPath = "path/to/output";
 
 try {
@@ -264,7 +264,7 @@ The `ImageFromPdfConfig` class is used to configure how images are processed bef
 Example Usage:
 
 ```dart
-final input = MergeInput.path("path/to/input.pdf");
+final input = MergeInputPath("path/to/input.pdf");
 final outputDirPath = "path/to/output";
 
 try {

--- a/example/integration_test/integration_test.dart
+++ b/example/integration_test/integration_test.dart
@@ -22,7 +22,7 @@ void main() {
       final outputPath = await helper.getOutputFilePath();
 
       final result = await PdfCombiner.createImageFromPDF(
-        input: MergeInput.path(inputPaths[0]),
+        input: MergeInputPath(inputPaths[0]),
         outputDirPath: outputPath,
       );
 
@@ -37,7 +37,7 @@ void main() {
 
       await expectLater(
         () => PdfCombiner.createImageFromPDF(
-          input: MergeInput.path(inputPaths[0]),
+          input: MergeInputPath(inputPaths[0]),
           outputDirPath: outputPath,
         ),
         throwsA(
@@ -59,7 +59,7 @@ void main() {
 
       await expectLater(
         () => PdfCombiner.createImageFromPDF(
-          input: MergeInput.path(inputPaths[0]),
+          input: MergeInputPath(inputPaths[0]),
           outputDirPath: outputPath,
         ),
         throwsA(
@@ -79,7 +79,7 @@ void main() {
       final outputPath = await helper.getOutputFilePath();
 
       final result = await PdfCombiner.createImageFromPDF(
-          input: MergeInput.path(inputPaths[0]), outputDirPath: outputPath);
+          input: MergeInputPath(inputPaths[0]), outputDirPath: outputPath);
 
       expect(result.length, 1);
       expect(result, ['${TestFileHelper.basePath}/image_1.png']);
@@ -91,7 +91,7 @@ void main() {
       final outputPath = await helper.getOutputFilePath();
 
       final result = await PdfCombiner.createImageFromPDF(
-          input: MergeInput.path(inputPaths[0]),
+          input: MergeInputPath(inputPaths[0]),
           outputDirPath: outputPath,
           config: ImageFromPdfConfig(createOneImage: false));
 
@@ -107,7 +107,7 @@ void main() {
       final outputPath = await helper.getOutputFilePath('merged_output.pdf');
 
       final result = await PdfCombiner.createPDFFromMultipleImages(
-        inputs: inputPaths.map((p) => MergeInput.path(p)).toList(),
+        inputs: inputPaths.map(MergeInputPath.new).toList(),
         outputPath: outputPath,
       );
 
@@ -138,7 +138,7 @@ void main() {
 
       await expectLater(
         () => PdfCombiner.createPDFFromMultipleImages(
-          inputs: inputPaths.map((p) => MergeInput.path(p)).toList(),
+          inputs: inputPaths.map(MergeInputPath.new).toList(),
           outputPath: outputPath,
         ),
         throwsA(
@@ -162,7 +162,7 @@ void main() {
 
       await expectLater(
         () => PdfCombiner.createPDFFromMultipleImages(
-          inputs: inputPaths.map((p) => MergeInput.path(p)).toList(),
+          inputs: inputPaths.map(MergeInputPath.new).toList(),
           outputPath: outputPath,
         ),
         throwsA(
@@ -193,7 +193,7 @@ void main() {
 
       await tester.runAsync(() async {
         await PdfCombiner.createPDFFromMultipleImages(
-          inputs: [MergeInput.path(sampleHeicPath)],
+          inputs: [MergeInputPath(sampleHeicPath)],
           outputPath: outputPath,
         );
       });
@@ -212,7 +212,7 @@ void main() {
       final outputPath = await helper.getOutputFilePath('merged_output.pdf');
 
       final result = await PdfCombiner.mergeMultiplePDFs(
-        inputs: inputPaths.map((p) => MergeInput.path(p)).toList(),
+        inputs: inputPaths.map(MergeInputPath.new).toList(),
         outputPath: outputPath,
       );
 
@@ -225,7 +225,7 @@ void main() {
       final outputPath = await helper.getOutputFilePath('merged_output.pdf');
 
       final result = await PdfCombiner.mergeMultiplePDFs(
-        inputs: inputPaths.map((p) => MergeInput.path(p)).toList(),
+        inputs: inputPaths.map(MergeInputPath.new).toList(),
         outputPath: outputPath,
       );
 
@@ -259,7 +259,7 @@ void main() {
 
       await expectLater(
         () => PdfCombiner.mergeMultiplePDFs(
-          inputs: inputPaths.map((p) => MergeInput.path(p)).toList(),
+          inputs: inputPaths.map(MergeInputPath.new).toList(),
           outputPath: outputPath,
         ),
         throwsA(
@@ -282,7 +282,7 @@ void main() {
 
       await expectLater(
         () => PdfCombiner.mergeMultiplePDFs(
-          inputs: inputPaths.map((p) => MergeInput.path(p)).toList(),
+          inputs: inputPaths.map(MergeInputPath.new).toList(),
           outputPath: outputPath,
         ),
         throwsA(

--- a/example/lib/models/input_source_type.dart
+++ b/example/lib/models/input_source_type.dart
@@ -1,0 +1,5 @@
+enum InputSourceType {
+  path,
+  bytes,
+}
+

--- a/example/lib/view_models/pdf_combiner_view_model.dart
+++ b/example/lib/view_models/pdf_combiner_view_model.dart
@@ -9,12 +9,14 @@ import 'package:pdf_combiner/models/merge_input.dart';
 import 'package:pdf_combiner/pdf_combiner.dart';
 import 'package:platform_detail/platform_detail.dart';
 
+import '../models/input_source_type.dart';
+
 class PdfCombinerViewModel {
   List<MergeInput> selectedFiles = []; // List of selected files
   List<String> outputFiles = []; // Path for the combined output file
 
   /// Function to pick PDF files from the device (old method)
-  Future<void> pickFiles(MergeInputType fileType) async {
+  Future<void> pickFiles(InputSourceType fileType) async {
     final result = await FilePicker.pickFiles(
       type: FileType.custom,
       allowedExtensions: ['pdf', 'jpg', 'png', 'heic'],
@@ -23,30 +25,26 @@ class PdfCombinerViewModel {
     );
     if (result == null) return;
     switch (fileType) {
-      case MergeInputType.path:
+      case InputSourceType.path:
         selectedFiles +=
             result.files.map((file) => MergeInputPath(file.path!)).toList();
         break;
-      case MergeInputType.bytes:
+      case InputSourceType.bytes:
         selectedFiles +=
             result.files.map((file) => MergeInputBytes(file.bytes!)).toList();
         break;
-      case MergeInputType.url:
-        throw UnsupportedError(
-          'MergeInputType.url is not supported by the file picker example.',
-        );
     }
   }
 
   /// Function to pick PDF files from the device
   Future<void> addFilesDragAndDrop(
-      MergeInputType fileType, List<DropItem> files) async {
+      InputSourceType fileType, List<DropItem> files) async {
     switch (fileType) {
-      case MergeInputType.path:
+      case InputSourceType.path:
         selectedFiles +=
             files.map((file) => MergeInputPath(file.path)).toList();
         break;
-      case MergeInputType.bytes:
+      case InputSourceType.bytes:
         selectedFiles += await Future.wait(
           files.map(
             (file) async => MergeInputBytes(
@@ -55,10 +53,6 @@ class PdfCombinerViewModel {
           ),
         );
         break;
-      case MergeInputType.url:
-        throw UnsupportedError(
-          'MergeInputType.url is not supported by drag and drop in the example.',
-        );
     }
 
     outputFiles = [];

--- a/example/lib/view_models/pdf_combiner_view_model.dart
+++ b/example/lib/view_models/pdf_combiner_view_model.dart
@@ -25,12 +25,16 @@ class PdfCombinerViewModel {
     switch (fileType) {
       case MergeInputType.path:
         selectedFiles +=
-            result.files.map((file) => MergeInput.path(file.path!)).toList();
+            result.files.map((file) => MergeInputPath(file.path!)).toList();
         break;
       case MergeInputType.bytes:
         selectedFiles +=
-            result.files.map((file) => MergeInput.bytes(file.bytes!)).toList();
+            result.files.map((file) => MergeInputBytes(file.bytes!)).toList();
         break;
+      case MergeInputType.url:
+        throw UnsupportedError(
+          'MergeInputType.url is not supported by the file picker example.',
+        );
     }
   }
 
@@ -40,17 +44,21 @@ class PdfCombinerViewModel {
     switch (fileType) {
       case MergeInputType.path:
         selectedFiles +=
-            files.map((file) => MergeInput.path(file.path)).toList();
+            files.map((file) => MergeInputPath(file.path)).toList();
         break;
       case MergeInputType.bytes:
         selectedFiles += await Future.wait(
           files.map(
-            (file) async => MergeInput.bytes(
+            (file) async => MergeInputBytes(
               await file.readAsBytes(),
             ),
           ),
         );
         break;
+      case MergeInputType.url:
+        throw UnsupportedError(
+          'MergeInputType.url is not supported by drag and drop in the example.',
+        );
     }
 
     outputFiles = [];

--- a/example/lib/views/pdf_combiner_screen.dart
+++ b/example/lib/views/pdf_combiner_screen.dart
@@ -64,9 +64,6 @@ class _PdfCombinerScreenState extends State<PdfCombinerScreen> {
           children: [
               DropTarget(
                 onDragDone: (details) async {
-                  // Dialog hidden: default behaviour
-                  // - web: bytes
-                  // - other platforms: path
                   final fileType = PlatformDetail.isWeb
                       ? MergeInputType.bytes
                       : MergeInputType.path;

--- a/example/lib/views/pdf_combiner_screen.dart
+++ b/example/lib/views/pdf_combiner_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data' show Uint8List;
+
 import 'package:desktop_drop/desktop_drop.dart';
 import 'package:file_magic_number/file_magic_number.dart';
 import 'package:flutter/material.dart';
@@ -9,23 +11,43 @@ import 'package:pdf_combiner_example/utils/uint8list_extension.dart';
 // file_type_dialog intentionally not used: dialog hidden by default; developers may enable it if desired.
 import 'package:pdf_combiner_example/views/widgets/file_type_icon.dart';
 
+import '../models/input_source_type.dart';
 import '../view_models/pdf_combiner_view_model.dart';
 import 'package:platform_detail/platform_detail.dart';
 
 extension on MergeInput {
   String fileName(int? index) {
-    switch (type) {
-      case MergeInputType.path:
-        return p.basename(path ?? '');
-      case MergeInputType.bytes:
+    switch (this) {
+      case MergeInputPath(:final path):
+        return p.basename(path);
+      case MergeInputBytes():
         return 'File in bytes $index';
-      case MergeInputType.url:
-        final parsedUrl = Uri.tryParse(url ?? '');
+      case MergeInputUrl(:final url):
+        final parsedUrl = Uri.tryParse(url);
         final urlPath = parsedUrl?.path;
         if (urlPath != null && urlPath.isNotEmpty) {
           return p.basename(urlPath);
         }
-        return url ?? 'Remote URL $index';
+        return url;
+      default:
+        return sourceLabel;
+    }
+  }
+
+  Future<Uint8List?> previewBytes() async {
+    switch (this) {
+      case MergeInputBytes(:final bytes):
+        return bytes;
+      case MergeInputPath(:final path):
+        return Uint8List.fromList(
+          await FileMagicNumber.getBytesFromPathOrBlob(path),
+        );
+      case MergeInputUrl(:final url):
+        return Uint8List.fromList(
+          await FileMagicNumber.getBytesFromPathOrBlob(url),
+        );
+      default:
+        return null;
     }
   }
 }
@@ -65,8 +87,8 @@ class _PdfCombinerScreenState extends State<PdfCombinerScreen> {
               DropTarget(
                 onDragDone: (details) async {
                   final fileType = PlatformDetail.isWeb
-                      ? MergeInputType.bytes
-                      : MergeInputType.path;
+                      ? InputSourceType.bytes
+                      : InputSourceType.path;
                   await _viewModel.addFilesDragAndDrop(fileType, details.files);
                   setState(() {});
                 },
@@ -101,7 +123,7 @@ class _PdfCombinerScreenState extends State<PdfCombinerScreen> {
                                   ),
                                   child: ListTile(
                                     leading: FileTypeIcon(
-                                        input: MergeInput.path(
+                                        input: MergeInputPath(
                                             _viewModel.outputFiles[index])),
                                     title: Text(
                                       p.basename(_viewModel.outputFiles[index]),
@@ -187,20 +209,9 @@ class _PdfCombinerScreenState extends State<PdfCombinerScreen> {
                                       await _openInputFile(index);
                                     },
                                     subtitle: FutureBuilder(
-                                        future: switch (_viewModel
-                                            .selectedFiles[index].type) {
-                                          MergeInputType.bytes => Future.value(
-                                              _viewModel
-                                                  .selectedFiles[index].bytes),
-                                          MergeInputType.path => FileMagicNumber
-                                              .getBytesFromPathOrBlob(_viewModel
-                                                  .selectedFiles[index]
-                                                  .toString()),
-                                          MergeInputType.url => FileMagicNumber
-                                              .getBytesFromPathOrBlob(_viewModel
-                                                  .selectedFiles[index]
-                                                  .toString()),
-                                        },
+                                        future: _viewModel
+                                            .selectedFiles[index]
+                                            .previewBytes(),
                                         builder: (context, snapshot) {
                                           if (snapshot.connectionState ==
                                               ConnectionState.waiting) {
@@ -286,8 +297,8 @@ class _PdfCombinerScreenState extends State<PdfCombinerScreen> {
     // - web: bytes
     // - other platforms: path
     final fileType = PlatformDetail.isWeb
-        ? MergeInputType.bytes
-        : MergeInputType.path;
+        ? InputSourceType.bytes
+        : InputSourceType.path;
     await _viewModel.pickFiles(fileType);
     setState(() {});
   }
@@ -358,18 +369,12 @@ class _PdfCombinerScreenState extends State<PdfCombinerScreen> {
 
   Future<void> _openInputFile(int index) async {
     if (index < _viewModel.selectedFiles.length) {
-      switch (_viewModel.selectedFiles[index].type) {
-        case MergeInputType.path:
-          final result =
-              await OpenFile.open(_viewModel.selectedFiles[index].toString());
-          if (result.type != ResultType.done) {
-            _showSnackbarSafely(
-                'Failed to open file. Error: ${result.message}');
-          }
-          return;
-        case MergeInputType.bytes:
-        case MergeInputType.url:
-          return;
+      final input = _viewModel.selectedFiles[index];
+      if (input case MergeInputPath(:final path)) {
+        final result = await OpenFile.open(path);
+        if (result.type != ResultType.done) {
+          _showSnackbarSafely('Failed to open file. Error: ${result.message}');
+        }
       }
     }
   }

--- a/example/lib/views/pdf_combiner_screen.dart
+++ b/example/lib/views/pdf_combiner_screen.dart
@@ -6,10 +6,11 @@ import 'package:path/path.dart' as p;
 import 'package:pdf_combiner/exception/pdf_combiner_exception.dart';
 import 'package:pdf_combiner/models/merge_input.dart';
 import 'package:pdf_combiner_example/utils/uint8list_extension.dart';
-import 'package:pdf_combiner_example/views/widgets/file_type_dialog.dart';
+// file_type_dialog intentionally not used: dialog hidden by default; developers may enable it if desired.
 import 'package:pdf_combiner_example/views/widgets/file_type_icon.dart';
 
 import '../view_models/pdf_combiner_view_model.dart';
+import 'package:platform_detail/platform_detail.dart';
 
 extension on MergeInput {
   String fileName(int? index) {
@@ -18,6 +19,13 @@ extension on MergeInput {
         return p.basename(path ?? '');
       case MergeInputType.bytes:
         return 'File in bytes $index';
+      case MergeInputType.url:
+        final parsedUrl = Uri.tryParse(url ?? '');
+        final urlPath = parsedUrl?.path;
+        if (urlPath != null && urlPath.isNotEmpty) {
+          return p.basename(urlPath);
+        }
+        return url ?? 'Remote URL $index';
     }
   }
 }
@@ -54,14 +62,17 @@ class _PdfCombinerScreenState extends State<PdfCombinerScreen> {
       body: SafeArea(
         child: Stack(
           children: [
-            DropTarget(
-              onDragDone: (details) async {
-                final fileType =
-                    await showFileTypeDialog(context); // Show dialog
-                if (fileType == null) return;
-                await _viewModel.addFilesDragAndDrop(fileType, details.files);
-                setState(() {});
-              },
+              DropTarget(
+                onDragDone: (details) async {
+                  // Dialog hidden: default behaviour
+                  // - web: bytes
+                  // - other platforms: path
+                  final fileType = PlatformDetail.isWeb
+                      ? MergeInputType.bytes
+                      : MergeInputType.path;
+                  await _viewModel.addFilesDragAndDrop(fileType, details.files);
+                  setState(() {});
+                },
               child: (_viewModel.isEmpty())
                   ? Center(
                       child: Image.asset('assets/files/home.png'),
@@ -188,6 +199,10 @@ class _PdfCombinerScreenState extends State<PdfCombinerScreen> {
                                               .getBytesFromPathOrBlob(_viewModel
                                                   .selectedFiles[index]
                                                   .toString()),
+                                          MergeInputType.url => FileMagicNumber
+                                              .getBytesFromPathOrBlob(_viewModel
+                                                  .selectedFiles[index]
+                                                  .toString()),
                                         },
                                         builder: (context, snapshot) {
                                           if (snapshot.connectionState ==
@@ -270,8 +285,12 @@ class _PdfCombinerScreenState extends State<PdfCombinerScreen> {
 
   // Function to pick PDF files from the device
   Future<void> _pickFiles() async {
-    final fileType = await showFileTypeDialog(context);
-    if (fileType == null) return;
+    // Dialog hidden: default behaviour
+    // - web: bytes
+    // - other platforms: path
+    final fileType = PlatformDetail.isWeb
+        ? MergeInputType.bytes
+        : MergeInputType.path;
     await _viewModel.pickFiles(fileType);
     setState(() {});
   }
@@ -352,6 +371,7 @@ class _PdfCombinerScreenState extends State<PdfCombinerScreen> {
           }
           return;
         case MergeInputType.bytes:
+        case MergeInputType.url:
           return;
       }
     }

--- a/example/lib/views/widgets/file_type_dialog.dart
+++ b/example/lib/views/widgets/file_type_dialog.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:pdf_combiner/models/merge_input.dart';
 
-Future<MergeInputType?> showFileTypeDialog(BuildContext context) async =>
-    showDialog<MergeInputType>(
+import '../../models/input_source_type.dart';
+
+Future<InputSourceType?> showFileTypeDialog(BuildContext context) async =>
+    showDialog<InputSourceType>(
       context: context,
       barrierDismissible: false,
       builder: (context) => AlertDialog(
@@ -11,11 +12,11 @@ Future<MergeInputType?> showFileTypeDialog(BuildContext context) async =>
         actions: [
           TextButton(
             child: const Text('Path'),
-            onPressed: () => Navigator.of(context).pop(MergeInputType.path),
+            onPressed: () => Navigator.of(context).pop(InputSourceType.path),
           ),
           TextButton(
-            child: Text('Bytes'),
-            onPressed: () => Navigator.of(context).pop(MergeInputType.bytes),
+            child: const Text('Bytes'),
+            onPressed: () => Navigator.of(context).pop(InputSourceType.bytes),
           ),
         ],
       ),

--- a/example/lib/views/widgets/file_type_icon.dart
+++ b/example/lib/views/widgets/file_type_icon.dart
@@ -11,20 +11,24 @@ class FileTypeIcon extends StatelessWidget {
   Widget build(BuildContext context) {
     return TextButton(
       onPressed: () {
-        switch (input.type) {
-          case MergeInputType.path:
-            OpenFile.open(input.path!);
-          case MergeInputType.bytes:
-            null;
+        if (input.path != null) {
+          OpenFile.open(input.path!);
         }
       },
       child: FutureBuilder(
-          future: switch (input.type) {
-            MergeInputType.bytes => Future.value(
-                FileMagicNumber.detectFileTypeFromBytes(input.bytes!)),
-            MergeInputType.path =>
-              FileMagicNumber.detectFileTypeFromPathOrBlob(input.path!),
-          },
+          future: () {
+            if (input.bytes != null) {
+              return Future.value(
+                  FileMagicNumber.detectFileTypeFromBytes(input.bytes!));
+            }
+            if (input.path != null) {
+              return FileMagicNumber.detectFileTypeFromPathOrBlob(input.path!);
+            }
+            if (input.url != null) {
+              return FileMagicNumber.detectFileTypeFromPathOrBlob(input.url!);
+            }
+            return Future.value(null);
+          }(),
           builder: (context, snapshot) {
             if (snapshot.connectionState == ConnectionState.waiting) {
               return const CircularProgressIndicator();

--- a/example/macos/Flutter/Flutter-Debug.xcconfig
+++ b/example/macos/Flutter/Flutter-Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/example/macos/Flutter/Flutter-Release.xcconfig
+++ b/example/macos/Flutter/Flutter-Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/example/macos/Runner.xcodeproj/project.pbxproj
@@ -27,7 +27,9 @@
 		33CC10F32044A3C60003C045 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F22044A3C60003C045 /* Assets.xcassets */; };
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
+		345D0F6860586E387FD8000A /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D05B9A9A00922D312AC704FC /* Pods_RunnerTests.framework */; };
 		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
+		BE3550610ABE3838D69F1A35 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1703E4CDA2D848324BCC26AB /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -61,6 +63,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1703E4CDA2D848324BCC26AB /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		331C80D5294CF71000263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		331C80D7294CF71000263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		333000ED22D3DE5D00554162 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
@@ -77,13 +80,16 @@
 		33E51913231747F40026EE4D /* DebugProfile.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = DebugProfile.entitlements; sourceTree = "<group>"; };
 		33E51914231749380026EE4D /* Release.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = Release.entitlements; sourceTree = "<group>"; };
 		33E5194F232828860026EE4D /* AppInfo.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = AppInfo.xcconfig; sourceTree = "<group>"; };
+		4EF8BE4CEC95DE1610632C16 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		5D8313077BDD7E8EADC357DA /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
-		9D1AE2797F1122D32F84B089 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
-		B916C8C968B7FF4C73A9F635 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
-		BB434C532BA40B0145EF9C1C /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
+		B30725933066C331AC662544 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		BB6EC834E52E3156E5B2E2D2 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
+		D05B9A9A00922D312AC704FC /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DA52EC65FEB399BC982803E2 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		F3607A175A81798C3B49738C /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -91,6 +97,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				345D0F6860586E387FD8000A /* Pods_RunnerTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -99,6 +106,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */,
+				BE3550610ABE3838D69F1A35 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -132,7 +140,7 @@
 				331C80D6294CF71000263BE5 /* RunnerTests */,
 				33CC10EE2044A3C60003C045 /* Products */,
 				BB2FC7C8E2515C2F79195568 /* Pods */,
-				E40C98A9BBE6C857EB875CE6 /* Frameworks */,
+				833F73C22F262D02AB687219 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -181,9 +189,24 @@
 			path = Runner;
 			sourceTree = "<group>";
 		};
+		833F73C22F262D02AB687219 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				1703E4CDA2D848324BCC26AB /* Pods_Runner.framework */,
+				D05B9A9A00922D312AC704FC /* Pods_RunnerTests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		BB2FC7C8E2515C2F79195568 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
+				DA52EC65FEB399BC982803E2 /* Pods-Runner.debug.xcconfig */,
+				4EF8BE4CEC95DE1610632C16 /* Pods-Runner.release.xcconfig */,
+				B30725933066C331AC662544 /* Pods-Runner.profile.xcconfig */,
+				5D8313077BDD7E8EADC357DA /* Pods-RunnerTests.debug.xcconfig */,
+				F3607A175A81798C3B49738C /* Pods-RunnerTests.release.xcconfig */,
+				BB6EC834E52E3156E5B2E2D2 /* Pods-RunnerTests.profile.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -195,6 +218,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C80DE294CF71000263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
+				0802A54F7B33EE5256C0DFC0 /* [CP] Check Pods Manifest.lock */,
 				331C80D1294CF70F00263BE5 /* Sources */,
 				331C80D2294CF70F00263BE5 /* Frameworks */,
 				331C80D3294CF70F00263BE5 /* Resources */,
@@ -213,11 +237,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 33CC10FB2044A3C60003C045 /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				A2CF6F4C82C5C548A8D3591C /* [CP] Check Pods Manifest.lock */,
 				33CC10E92044A3C60003C045 /* Sources */,
 				33CC10EA2044A3C60003C045 /* Frameworks */,
 				33CC10EB2044A3C60003C045 /* Resources */,
 				33CC110E2044A8840003C045 /* Bundle Framework */,
 				3399D490228B24CF009A79C7 /* ShellScript */,
+				A5430E874356B36877011E31 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -306,21 +332,26 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		027C74EECD41CD84329B6AAA /* [CP] Embed Pods Frameworks */ = {
+		0802A54F7B33EE5256C0DFC0 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			name = "[CP] Embed Pods Frameworks";
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
 			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		3399D490228B24CF009A79C7 /* ShellScript */ = {
@@ -360,6 +391,45 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/macos_assemble.sh && touch Flutter/ephemeral/tripwire";
+		};
+		A2CF6F4C82C5C548A8D3591C /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		A5430E874356B36877011E31 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -412,6 +482,7 @@
 /* Begin XCBuildConfiguration section */
 		331C80DB294CF71000263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 5D8313077BDD7E8EADC357DA /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
@@ -426,6 +497,7 @@
 		};
 		331C80DC294CF71000263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = F3607A175A81798C3B49738C /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
@@ -440,6 +512,7 @@
 		};
 		331C80DD294CF71000263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = BB6EC834E52E3156E5B2E2D2 /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;

--- a/lib/communication/pdf_combiner_method_channel.dart
+++ b/lib/communication/pdf_combiner_method_channel.dart
@@ -17,6 +17,18 @@ class MethodChannelPdfCombiner extends PdfCombinerPlatform {
   @visibleForTesting
   final MethodChannel methodChannel = const MethodChannel('pdf_combiner');
 
+  String _requirePath(MergeInput input) {
+    final path = input.path;
+    if (path != null) {
+      return path;
+    }
+    throw ArgumentError.value(
+      input,
+      'input',
+      'MethodChannelPdfCombiner only accepts path-based inputs.',
+    );
+  }
+
   /// Merges multiple PDF files into a single PDF.
   ///
   /// This method sends a request to the native platform to merge the PDF files
@@ -34,7 +46,7 @@ class MethodChannelPdfCombiner extends PdfCombinerPlatform {
     required List<MergeInput> inputs,
     required String outputPath,
   }) async {
-    final inputPaths = inputs.map((input) => input.path).toList();
+    final inputPaths = inputs.map(_requirePath).toList();
     final result = await methodChannel.invokeMethod<String>(
       'mergeMultiplePDF',
       {'paths': inputPaths, 'outputDirPath': outputPath},
@@ -64,7 +76,7 @@ class MethodChannelPdfCombiner extends PdfCombinerPlatform {
     required String outputPath,
     PdfFromMultipleImageConfig config = const PdfFromMultipleImageConfig(),
   }) async {
-    final inputPaths = inputs.map((input) => input.path).toList();
+    final inputPaths = inputs.map(_requirePath).toList();
     final result = await methodChannel.invokeMethod<String>(
       'createPDFFromMultipleImage',
       {
@@ -103,7 +115,7 @@ class MethodChannelPdfCombiner extends PdfCombinerPlatform {
     final result = await methodChannel.invokeMethod<List<dynamic>>(
       'createImageFromPDF',
       {
-        'path': input.path,
+        'path': _requirePath(input),
         'outputDirPath': outputPath,
         'height': config.rescale.height,
         'width': config.rescale.width,

--- a/lib/isolates/images_from_pdf_isolate.dart
+++ b/lib/isolates/images_from_pdf_isolate.dart
@@ -30,7 +30,7 @@ class ImagesFromPdfIsolate {
   }) async {
     if (PdfCombiner.isMock) {
       return await PdfCombinerPlatform.instance.createImageFromPDF(
-        input: MergeInput.path(inputPath),
+        input: MergeInputPath(inputPath),
         outputPath: outputDirectory,
         config: config,
       );
@@ -62,7 +62,7 @@ class ImagesFromPdfIsolate {
     }
 
     return await PdfCombinerPlatform.instance.createImageFromPDF(
-      input: MergeInput.path(inputPath),
+      input: MergeInputPath(inputPath),
       outputPath: outputDirectory,
       config: config,
     );

--- a/lib/isolates/merge_pdfs_isolate.dart
+++ b/lib/isolates/merge_pdfs_isolate.dart
@@ -27,7 +27,7 @@ class MergePdfsIsolate {
   }) async {
     if (PdfCombiner.isMock) {
       return await PdfCombinerPlatform.instance.mergeMultiplePDFs(
-        inputs: inputPaths.map((e) => MergeInput.path(e)).toList(),
+        inputs: inputPaths.map(MergeInputPath.new).toList(),
         outputPath: outputPath,
       );
     }
@@ -54,7 +54,7 @@ class MergePdfsIsolate {
     }
 
     return await PdfCombinerPlatform.instance.mergeMultiplePDFs(
-      inputs: inputPaths.map((e) => MergeInput.path(e)).toList(),
+      inputs: inputPaths.map(MergeInputPath.new).toList(),
       outputPath: outputPath,
     );
   }

--- a/lib/isolates/pdf_from_multiple_images_isolate.dart
+++ b/lib/isolates/pdf_from_multiple_images_isolate.dart
@@ -30,7 +30,7 @@ class PdfFromMultipleImagesIsolate {
   }) async {
     if (PdfCombiner.isMock) {
       return await PdfCombinerPlatform.instance.createPDFFromMultipleImages(
-        inputs: inputPaths.map((e) => MergeInput.path(e)).toList(),
+        inputs: inputPaths.map(MergeInputPath.new).toList(),
         outputPath: outputPath,
         config: config,
       );
@@ -62,7 +62,7 @@ class PdfFromMultipleImagesIsolate {
     }
 
     return await PdfCombinerPlatform.instance.createPDFFromMultipleImages(
-      inputs: inputPaths.map((e) => MergeInput.path(e)).toList(),
+      inputs: inputPaths.map(MergeInputPath.new).toList(),
       outputPath: outputPath,
       config: config,
     );

--- a/lib/models/merge_input.dart
+++ b/lib/models/merge_input.dart
@@ -4,34 +4,76 @@ import 'dart:typed_data' show Uint8List;
 enum MergeInputType {
   path,
   bytes,
+  url,
 }
 
-/// A class representing an input for merging PDFs.
+/// An abstract class representing an input for merging PDFs.
 ///
-/// It can be created from a file path or a byte array.
-class MergeInput {
-  final String? path;
-  final Uint8List? bytes;
+/// Subclasses must provide the concrete input (path, bytes, url).
+abstract class MergeInput {
   final MergeInputType type;
 
-  const MergeInput(this.type, {this.path, this.bytes})
-      : assert((path != null) != (bytes != null));
+  const MergeInput(this.type);
 
-  /// Creates a [MergeInput] from a file path.
-  factory MergeInput.path(String path) =>
-      MergeInput(MergeInputType.path, path: path);
+  /// Factory helpers for convenience and backwards compatibility.
+  factory MergeInput.path(String path) => MergeInputPath(path);
+  factory MergeInput.bytes(Uint8List bytes) => MergeInputBytes(bytes);
+  factory MergeInput.url(String url) => MergeInputUrl(url);
 
-  /// Creates a [MergeInput] from a byte array.
-  factory MergeInput.bytes(Uint8List bytes) =>
-      MergeInput(MergeInputType.bytes, bytes: bytes);
+  /// Returns the local path when this input is backed by a file path.
+  String? get path => switch (this) {
+        MergeInputPath(:final path) => path,
+        _ => null,
+      };
+
+  /// Returns the in-memory bytes when this input is backed by raw bytes.
+  Uint8List? get bytes => switch (this) {
+        MergeInputBytes(:final bytes) => bytes,
+        _ => null,
+      };
+
+  /// Returns the remote URL when this input is backed by a URL.
+  String? get url => switch (this) {
+        MergeInputUrl(:final url) => url,
+        _ => null,
+      };
+
+  /// Returns a user-friendly identifier for logging and error messages.
+  String get sourceLabel => path ?? url ?? 'File in bytes';
 
   @override
-  String toString() {
-    switch (type) {
-      case MergeInputType.path:
-        return path!;
-      case MergeInputType.bytes:
-        return bytes!.toString();
-    }
-  }
+  String toString();
+}
+
+/// A [MergeInput] that references a file system path.
+class MergeInputPath extends MergeInput {
+  @override
+  final String path;
+
+  MergeInputPath(this.path) : super(MergeInputType.path);
+
+  @override
+  String toString() => path;
+}
+
+/// A [MergeInput] that contains raw bytes.
+class MergeInputBytes extends MergeInput {
+  @override
+  final Uint8List bytes;
+
+  MergeInputBytes(this.bytes) : super(MergeInputType.bytes);
+
+  @override
+  String toString() => bytes.toString();
+}
+
+/// A [MergeInput] that references a remote URL.
+class MergeInputUrl extends MergeInput {
+  @override
+  final String url;
+
+  MergeInputUrl(this.url) : super(MergeInputType.url);
+
+  @override
+  String toString() => url;
 }

--- a/lib/models/merge_input.dart
+++ b/lib/models/merge_input.dart
@@ -1,24 +1,10 @@
 import 'dart:typed_data' show Uint8List;
 
-/// An enum representing the type of input for merging PDFs.
-enum MergeInputType {
-  path,
-  bytes,
-  url,
-}
-
 /// An abstract class representing an input for merging PDFs.
 ///
 /// Subclasses must provide the concrete input (path, bytes, url).
 abstract class MergeInput {
-  final MergeInputType type;
-
-  const MergeInput(this.type);
-
-  /// Factory helpers for convenience and backwards compatibility.
-  factory MergeInput.path(String path) => MergeInputPath(path);
-  factory MergeInput.bytes(Uint8List bytes) => MergeInputBytes(bytes);
-  factory MergeInput.url(String url) => MergeInputUrl(url);
+  const MergeInput();
 
   /// Returns the local path when this input is backed by a file path.
   String? get path => switch (this) {
@@ -41,6 +27,17 @@ abstract class MergeInput {
   /// Returns a user-friendly identifier for logging and error messages.
   String get sourceLabel => path ?? url ?? 'File in bytes';
 
+  /// Indicates whether this input must be materialized as a temporary resource.
+  bool get requiresTemporaryResource => this is! MergeInputPath;
+
+  /// Prefix used when a temporary file must be created for this input.
+  String get temporaryFilePrefix => switch (this) {
+        MergeInputPath() => 'path_input',
+        MergeInputBytes() => 'bytes_input',
+        MergeInputUrl() => 'url_input',
+        _ => throw StateError('Unsupported MergeInput subtype: $runtimeType'),
+      };
+
   @override
   String toString();
 }
@@ -50,7 +47,7 @@ class MergeInputPath extends MergeInput {
   @override
   final String path;
 
-  MergeInputPath(this.path) : super(MergeInputType.path);
+  const MergeInputPath(this.path);
 
   @override
   String toString() => path;
@@ -61,7 +58,7 @@ class MergeInputBytes extends MergeInput {
   @override
   final Uint8List bytes;
 
-  MergeInputBytes(this.bytes) : super(MergeInputType.bytes);
+  const MergeInputBytes(this.bytes);
 
   @override
   String toString() => bytes.toString();
@@ -72,7 +69,7 @@ class MergeInputUrl extends MergeInput {
   @override
   final String url;
 
-  MergeInputUrl(this.url) : super(MergeInputType.url);
+  const MergeInputUrl(this.url);
 
   @override
   String toString() => url;

--- a/lib/pdf_combiner.dart
+++ b/lib/pdf_combiner.dart
@@ -79,7 +79,7 @@ class PdfCombiner {
           );
           temporalPaths.add(response);
 
-          mutablePaths[i] = MergeInput.path(response);
+          mutablePaths[i] = MergeInputPath(response);
         }
       }
       final response = await PdfCombiner.mergeMultiplePDFs(
@@ -136,13 +136,8 @@ class PdfCombiner {
             inputs.map(
               (input) async {
                 final result = await DocumentUtils.prepareInput(input);
-                switch (input.type) {
-                  case MergeInputType.bytes:
-                  case MergeInputType.url:
-                    temportalFilePaths.add(result);
-                    break;
-                  case MergeInputType.path:
-                    break;
+                if (input.requiresTemporaryResource) {
+                  temportalFilePaths.add(result);
                 }
                 return result;
               },
@@ -218,13 +213,8 @@ class PdfCombiner {
             inputs.map(
               (input) async {
                 final result = await DocumentUtils.prepareInput(input);
-                switch (input.type) {
-                  case MergeInputType.bytes:
-                  case MergeInputType.url:
-                    temportalFilePaths.add(result);
-                    break;
-                  case MergeInputType.path:
-                    break;
+                if (input.requiresTemporaryResource) {
+                  temportalFilePaths.add(result);
                 }
                 return result;
               },
@@ -285,34 +275,13 @@ class PdfCombiner {
       bool success = await DocumentUtils.isPDF(input);
 
       if (!success) {
-        String inputTypeMessage;
-
-        switch (input.type) {
-          case MergeInputType.bytes:
-            inputTypeMessage = "File in bytes";
-            break;
-
-          case MergeInputType.path:
-            inputTypeMessage = input.path!;
-            break;
-
-          case MergeInputType.url:
-            inputTypeMessage = input.url!;
-            break;
-        }
-
         throw PdfCombinerException(PdfCombinerMessages.errorMessagePDF(
-          inputTypeMessage,
+          input.sourceLabel,
         ));
       } else {
         final inputPath = await DocumentUtils.prepareInput(input);
-        switch (input.type) {
-          case MergeInputType.bytes:
-          case MergeInputType.url:
-            temportalFilePath = inputPath;
-            break;
-          case MergeInputType.path:
-            break;
+        if (input.requiresTemporaryResource) {
+          temportalFilePath = inputPath;
         }
         final response = await ImagesFromPdfIsolate.createImageFromPDF(
           inputPath: inputPath,

--- a/lib/pdf_combiner.dart
+++ b/lib/pdf_combiner.dart
@@ -1,15 +1,14 @@
 import 'dart:async';
 
-import 'package:pdf_combiner/exception/pdf_combiner_exception.dart';
-import 'package:pdf_combiner/isolates/images_from_pdf_isolate.dart';
-import 'package:pdf_combiner/models/merge_input.dart';
-import 'package:pdf_combiner/models/pdf_from_multiple_image_config.dart';
-import 'package:pdf_combiner/responses/pdf_combiner_messages.dart';
-import 'package:pdf_combiner/utils/document_utils.dart';
-
+import 'exception/pdf_combiner_exception.dart';
+import 'isolates/images_from_pdf_isolate.dart';
 import 'isolates/merge_pdfs_isolate.dart';
 import 'isolates/pdf_from_multiple_images_isolate.dart';
 import 'models/image_from_pdf_config.dart';
+import 'models/merge_input.dart';
+import 'models/pdf_from_multiple_image_config.dart';
+import 'responses/pdf_combiner_messages.dart';
+import 'utils/document_utils_io.dart';
 
 /// The `PdfCombiner` class provides functionality for combining multiple PDF files.
 ///
@@ -69,7 +68,7 @@ class PdfCombiner {
         } else if (!isPDF && !isImage) {
           throw PdfCombinerException(
             PdfCombinerMessages.errorMessageMixed(
-              input.path ?? input.bytes.toString(),
+              input.sourceLabel,
             ),
           );
         }
@@ -123,7 +122,7 @@ class PdfCombiner {
 
         for (MergeInput input in inputs) {
           success = await DocumentUtils.isPDF(input);
-          path = input.path;
+          path = input.path ?? input.url ?? path;
         }
 
         final outputPathIsPDF = DocumentUtils.hasPDFExtension(outputPath);
@@ -139,6 +138,7 @@ class PdfCombiner {
                 final result = await DocumentUtils.prepareInput(input);
                 switch (input.type) {
                   case MergeInputType.bytes:
+                  case MergeInputType.url:
                     temportalFilePaths.add(result);
                     break;
                   case MergeInputType.path:
@@ -206,7 +206,7 @@ class PdfCombiner {
 
         while (i < inputs.length && success) {
           success = await DocumentUtils.isImage(inputs[i]);
-          path = inputs[i].path;
+          path = inputs[i].path ?? inputs[i].url ?? path;
           i++;
         }
 
@@ -220,6 +220,7 @@ class PdfCombiner {
                 final result = await DocumentUtils.prepareInput(input);
                 switch (input.type) {
                   case MergeInputType.bytes:
+                  case MergeInputType.url:
                     temportalFilePaths.add(result);
                     break;
                   case MergeInputType.path:
@@ -294,6 +295,10 @@ class PdfCombiner {
           case MergeInputType.path:
             inputTypeMessage = input.path!;
             break;
+
+          case MergeInputType.url:
+            inputTypeMessage = input.url!;
+            break;
         }
 
         throw PdfCombinerException(PdfCombinerMessages.errorMessagePDF(
@@ -303,6 +308,7 @@ class PdfCombiner {
         final inputPath = await DocumentUtils.prepareInput(input);
         switch (input.type) {
           case MergeInputType.bytes:
+          case MergeInputType.url:
             temportalFilePath = inputPath;
             break;
           case MergeInputType.path:

--- a/lib/pdf_combiner.dart
+++ b/lib/pdf_combiner.dart
@@ -8,7 +8,7 @@ import 'models/image_from_pdf_config.dart';
 import 'models/merge_input.dart';
 import 'models/pdf_from_multiple_image_config.dart';
 import 'responses/pdf_combiner_messages.dart';
-import 'utils/document_utils_io.dart';
+import 'utils/document_utils.dart';
 
 /// The `PdfCombiner` class provides functionality for combining multiple PDF files.
 ///

--- a/lib/pdf_combiner_web.dart
+++ b/lib/pdf_combiner_web.dart
@@ -2,9 +2,9 @@ import 'dart:async';
 import 'dart:js_interop';
 
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
-import 'package:pdf_combiner/models/merge_input.dart';
-import 'package:pdf_combiner/web/list_to_js_array_extension.dart';
-import 'package:pdf_combiner/web/pdf_combiner_web_bindings.dart';
+import 'models/merge_input.dart';
+import 'web/list_to_js_array_extension.dart';
+import 'web/pdf_combiner_web_bindings.dart';
 import 'package:web/web.dart';
 
 import 'communication/pdf_combiner_platform_interface.dart';

--- a/lib/utils/document_utils_io.dart
+++ b/lib/utils/document_utils_io.dart
@@ -24,19 +24,6 @@ extension on FileMagicNumberType {
   }
 }
 
-extension on MergeInput {
-  String filenamePrefix() {
-    switch (type) {
-      case MergeInputType.path:
-        return 'path_input';
-      case MergeInputType.bytes:
-        return 'bytes_input';
-      case MergeInputType.url:
-        return 'url_input';
-    }
-  }
-}
-
 /// Utility class for handling document-related checks in a file system environment.
 ///
 /// This implementation is designed for platforms with direct file system access,
@@ -72,25 +59,29 @@ class DocumentUtils {
   }
 
   static Future<FileMagicNumberType> _detectInputType(MergeInput input) async {
-    switch (input.type) {
-      case MergeInputType.path:
-        return FileMagicNumber.detectFileTypeFromPathOrBlob(input.path!);
-      case MergeInputType.bytes:
-        return FileMagicNumber.detectFileTypeFromBytes(input.bytes!);
-      case MergeInputType.url:
-        final bytes = await _downloadUrlBytes(input.url!);
+    switch (input) {
+      case MergeInputPath(:final path):
+        return FileMagicNumber.detectFileTypeFromPathOrBlob(path);
+      case MergeInputBytes(:final bytes):
         return FileMagicNumber.detectFileTypeFromBytes(bytes);
+      case MergeInputUrl(:final url):
+        final bytes = await _downloadUrlBytes(url);
+        return FileMagicNumber.detectFileTypeFromBytes(bytes);
+      default:
+        throw UnsupportedError('Unsupported MergeInput subtype: ${input.runtimeType}');
     }
   }
 
   static Future<Uint8List> _readInputBytes(MergeInput input) async {
-    switch (input.type) {
-      case MergeInputType.path:
-        return Uint8List.fromList(await File(input.path!).readAsBytes());
-      case MergeInputType.bytes:
-        return input.bytes!;
-      case MergeInputType.url:
-        return _downloadUrlBytes(input.url!);
+    switch (input) {
+      case MergeInputPath(:final path):
+        return Uint8List.fromList(await File(path).readAsBytes());
+      case MergeInputBytes(:final bytes):
+        return bytes;
+      case MergeInputUrl(:final url):
+        return _downloadUrlBytes(url);
+      default:
+        throw UnsupportedError('Unsupported MergeInput subtype: ${input.runtimeType}');
     }
   }
 
@@ -207,24 +198,22 @@ class DocumentUtils {
   ///
   /// **Returns:** The path to the prepared input file
   static Future<String> prepareInput(MergeInput input) async {
-    switch (input.type) {
-      case MergeInputType.path:
-        return input.path!;
-      case MergeInputType.bytes:
-      case MergeInputType.url:
-        final bytes = await _readInputBytes(input);
-        final fileType = FileMagicNumber.detectFileTypeFromBytes(bytes);
-        final tempDirPath = getTemporalFolderPath();
-        final tempDir = Directory(tempDirPath);
-        if (!await tempDir.exists()) {
-          await tempDir.create(recursive: true);
-        }
-        final fileName =
-            '${input.filenamePrefix()}_${DateTime.now().millisecondsSinceEpoch}_${Random().nextInt(10000)}${fileType.extension()}';
-        final tempPath = p.join(tempDirPath, fileName);
-        final file = File(tempPath);
-        await file.writeAsBytes(bytes);
-        return tempPath;
+    if (input case MergeInputPath(:final path)) {
+      return path;
     }
+
+    final bytes = await _readInputBytes(input);
+    final fileType = FileMagicNumber.detectFileTypeFromBytes(bytes);
+    final tempDirPath = getTemporalFolderPath();
+    final tempDir = Directory(tempDirPath);
+    if (!await tempDir.exists()) {
+      await tempDir.create(recursive: true);
+    }
+    final fileName =
+        '${input.temporaryFilePrefix}_${DateTime.now().millisecondsSinceEpoch}_${Random().nextInt(10000)}${fileType.extension()}';
+    final tempPath = p.join(tempDirPath, fileName);
+    final file = File(tempPath);
+    await file.writeAsBytes(bytes);
+    return tempPath;
   }
 }

--- a/lib/utils/document_utils_io.dart
+++ b/lib/utils/document_utils_io.dart
@@ -1,27 +1,38 @@
 import 'dart:io';
 import 'dart:math';
+import 'dart:typed_data';
 
 import 'package:file_magic_number/file_magic_number.dart';
 import 'package:path/path.dart' as p;
 import 'package:pdf_combiner/models/merge_input.dart';
 import 'package:pdf_combiner/pdf_combiner.dart';
 
-extension on MergeInputType {
+extension on FileMagicNumberType {
   String extension() {
     switch (this) {
-      case MergeInputType.path:
+      case FileMagicNumberType.pdf:
         return '.pdf';
-      case MergeInputType.bytes:
+      case FileMagicNumberType.png:
         return '.png';
+      case FileMagicNumberType.jpg:
+        return '.jpg';
+      case FileMagicNumberType.heic:
+        return '.heic';
+      default:
+        return '.bin';
     }
   }
+}
 
+extension on MergeInput {
   String filenamePrefix() {
-    switch (this) {
+    switch (type) {
       case MergeInputType.path:
-        return 'pdf_input';
+        return 'path_input';
       case MergeInputType.bytes:
-        return 'image_input';
+        return 'bytes_input';
+      case MergeInputType.url:
+        return 'url_input';
     }
   }
 }
@@ -36,6 +47,52 @@ extension on MergeInputType {
 /// file handling implementation through `DocumentUtilsWeb`.
 class DocumentUtils {
   static String _temporalDir = Directory.systemTemp.path;
+
+  static Future<Uint8List> _downloadUrlBytes(String url) async {
+    final uri = Uri.parse(url);
+    final client = HttpClient();
+
+    try {
+      final request = await client.getUrl(uri);
+      final response = await request.close();
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        throw HttpException(
+          'Failed to download input URL: ${response.statusCode}',
+          uri: uri,
+        );
+      }
+      final bytes = await response.fold<List<int>>(
+        <int>[],
+        (buffer, data) => buffer..addAll(data),
+      );
+      return Uint8List.fromList(bytes);
+    } finally {
+      client.close(force: true);
+    }
+  }
+
+  static Future<FileMagicNumberType> _detectInputType(MergeInput input) async {
+    switch (input.type) {
+      case MergeInputType.path:
+        return FileMagicNumber.detectFileTypeFromPathOrBlob(input.path!);
+      case MergeInputType.bytes:
+        return FileMagicNumber.detectFileTypeFromBytes(input.bytes!);
+      case MergeInputType.url:
+        final bytes = await _downloadUrlBytes(input.url!);
+        return FileMagicNumber.detectFileTypeFromBytes(bytes);
+    }
+  }
+
+  static Future<Uint8List> _readInputBytes(MergeInput input) async {
+    switch (input.type) {
+      case MergeInputType.path:
+        return Uint8List.fromList(await File(input.path!).readAsBytes());
+      case MergeInputType.bytes:
+        return input.bytes!;
+      case MergeInputType.url:
+        return _downloadUrlBytes(input.url!);
+    }
+  }
 
   /// Removes a list of temporary files from the file system.
   ///
@@ -103,15 +160,7 @@ class DocumentUtils {
   /// **Returns:** `true` if the file is a valid PDF, `false` otherwise
   /// (including when an error occurs during detection)
   static Future<bool> isPDF(MergeInput input) async {
-    switch (input.type) {
-      case MergeInputType.path:
-        return await FileMagicNumber.detectFileTypeFromPathOrBlob(
-                input.path!) ==
-            FileMagicNumberType.pdf;
-      case MergeInputType.bytes:
-        return FileMagicNumber.detectFileTypeFromBytes(input.bytes!) ==
-            FileMagicNumberType.pdf;
-    }
+    return await _detectInputType(input) == FileMagicNumberType.pdf;
   }
 
   /// Checks if the given file path has a PDF extension.
@@ -142,16 +191,7 @@ class DocumentUtils {
   /// **Returns:** `true` if the file is a PNG or JPEG image, `false` otherwise
   /// (including when an error occurs during detection)
   static Future<bool> isImage(MergeInput input) async {
-    late FileMagicNumberType fileType;
-    switch (input.type) {
-      case MergeInputType.path:
-        fileType =
-            await FileMagicNumber.detectFileTypeFromPathOrBlob(input.path!);
-        break;
-      case MergeInputType.bytes:
-        fileType = FileMagicNumber.detectFileTypeFromBytes(input.bytes!);
-        break;
-    }
+    final fileType = await _detectInputType(input);
     return fileType == FileMagicNumberType.png ||
         fileType == FileMagicNumberType.jpg ||
         fileType == FileMagicNumberType.heic;
@@ -171,16 +211,19 @@ class DocumentUtils {
       case MergeInputType.path:
         return input.path!;
       case MergeInputType.bytes:
+      case MergeInputType.url:
+        final bytes = await _readInputBytes(input);
+        final fileType = FileMagicNumber.detectFileTypeFromBytes(bytes);
         final tempDirPath = getTemporalFolderPath();
         final tempDir = Directory(tempDirPath);
         if (!await tempDir.exists()) {
           await tempDir.create(recursive: true);
         }
         final fileName =
-            '${input.type.filenamePrefix()}_${DateTime.now().millisecondsSinceEpoch}_${Random().nextInt(10000)}${input.type.extension()}';
+            '${input.filenamePrefix()}_${DateTime.now().millisecondsSinceEpoch}_${Random().nextInt(10000)}${fileType.extension()}';
         final tempPath = p.join(tempDirPath, fileName);
         final file = File(tempPath);
-        await file.writeAsBytes(input.bytes!);
+        await file.writeAsBytes(bytes);
         return tempPath;
     }
   }

--- a/lib/utils/document_utils_web.dart
+++ b/lib/utils/document_utils_web.dart
@@ -2,9 +2,29 @@ import 'dart:js_interop';
 import 'dart:typed_data';
 
 import 'package:file_magic_number/file_magic_number.dart';
+import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as p;
 import 'package:pdf_combiner/models/merge_input.dart';
 import 'package:web/web.dart' as web;
+
+extension on MergeInput {
+  Future<Uint8List> readBytes() async {
+    switch (type) {
+      case MergeInputType.path:
+        return Uint8List.fromList(
+          await FileMagicNumber.getBytesFromPathOrBlob(path!),
+        );
+      case MergeInputType.bytes:
+        return bytes!;
+      case MergeInputType.url:
+        final response = await http.get(Uri.parse(url!));
+        if (response.statusCode < 200 || response.statusCode >= 300) {
+          throw Exception('Failed to download input URL: ${response.statusCode}');
+        }
+        return response.bodyBytes;
+    }
+  }
+}
 
 /// Utility class for handling document-related checks in a web environment.
 ///
@@ -37,15 +57,9 @@ class DocumentUtils {
 
   /// Determines whether the given file path/blob corresponds to a PDF file.
   static Future<bool> isPDF(MergeInput input) async {
-    switch (input.type) {
-      case MergeInputType.path:
-        return await FileMagicNumber.detectFileTypeFromPathOrBlob(
-                input.path!) ==
-            FileMagicNumberType.pdf;
-      case MergeInputType.bytes:
-        return FileMagicNumber.detectFileTypeFromBytes(input.bytes!) ==
-            FileMagicNumberType.pdf;
-    }
+    final bytes = await input.readBytes();
+    return FileMagicNumber.detectFileTypeFromBytes(bytes) ==
+        FileMagicNumberType.pdf;
   }
 
   /// Checks if the given file path has a PDF extension.
@@ -54,16 +68,8 @@ class DocumentUtils {
 
   /// Determines whether the given file path/blob corresponds to an image file.
   static Future<bool> isImage(MergeInput input) async {
-    late FileMagicNumberType fileType;
-    switch (input.type) {
-      case MergeInputType.path:
-        fileType =
-            await FileMagicNumber.detectFileTypeFromPathOrBlob(input.path!);
-        break;
-      case MergeInputType.bytes:
-        fileType = FileMagicNumber.detectFileTypeFromBytes(input.bytes!);
-        break;
-    }
+    final bytes = await input.readBytes();
+    final fileType = FileMagicNumber.detectFileTypeFromBytes(bytes);
     return fileType == FileMagicNumberType.png ||
         fileType == FileMagicNumberType.jpg ||
         fileType == FileMagicNumberType.heic;
@@ -98,13 +104,15 @@ class DocumentUtils {
   /// Process a [MergeInput] and return a valid file path or blob URL.
   ///
   /// - [MergeInput.path]: Returns the path as-is.
-  /// - [MergeInput.bytes]: Creates a blob URL and returns it.
+  /// - [MergeInput.bytes] and [MergeInput.url]: Create a blob URL and return it.
   static Future<String> prepareInput(MergeInput input) async {
     switch (input.type) {
       case MergeInputType.path:
         return input.path!;
       case MergeInputType.bytes:
         return createBlobUrl(input.bytes!);
+      case MergeInputType.url:
+        return createBlobUrl(await input.readBytes());
     }
   }
 }

--- a/lib/utils/document_utils_web.dart
+++ b/lib/utils/document_utils_web.dart
@@ -9,19 +9,21 @@ import 'package:web/web.dart' as web;
 
 extension on MergeInput {
   Future<Uint8List> readBytes() async {
-    switch (type) {
-      case MergeInputType.path:
+    switch (this) {
+      case MergeInputPath(:final path):
         return Uint8List.fromList(
-          await FileMagicNumber.getBytesFromPathOrBlob(path!),
+          await FileMagicNumber.getBytesFromPathOrBlob(path),
         );
-      case MergeInputType.bytes:
-        return bytes!;
-      case MergeInputType.url:
-        final response = await http.get(Uri.parse(url!));
+      case MergeInputBytes(:final bytes):
+        return bytes;
+      case MergeInputUrl(:final url):
+        final response = await http.get(Uri.parse(url));
         if (response.statusCode < 200 || response.statusCode >= 300) {
           throw Exception('Failed to download input URL: ${response.statusCode}');
         }
         return response.bodyBytes;
+      default:
+        throw UnsupportedError('Unsupported MergeInput subtype: $runtimeType');
     }
   }
 }
@@ -106,13 +108,15 @@ class DocumentUtils {
   /// - [MergeInput.path]: Returns the path as-is.
   /// - [MergeInput.bytes] and [MergeInput.url]: Create a blob URL and return it.
   static Future<String> prepareInput(MergeInput input) async {
-    switch (input.type) {
-      case MergeInputType.path:
-        return input.path!;
-      case MergeInputType.bytes:
-        return createBlobUrl(input.bytes!);
-      case MergeInputType.url:
+    switch (input) {
+      case MergeInputPath(:final path):
+        return path;
+      case MergeInputBytes(:final bytes):
+        return createBlobUrl(bytes);
+      case MergeInputUrl():
         return createBlobUrl(await input.readBytes());
+      default:
+        throw UnsupportedError('Unsupported MergeInput subtype: ${input.runtimeType}');
     }
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   plugin_platform_interface: ^2.0.2
   web: ^1.0.0
   file_magic_number: ^1.4.1
+  http: ^1.2.2
 
 dev_dependencies:
   flutter_test:

--- a/test/document_utils_bytes_test.dart
+++ b/test/document_utils_bytes_test.dart
@@ -8,6 +8,8 @@ import 'package:pdf_combiner/utils/document_utils.dart';
 
 void main() {
   group('DocumentUtils with bytes', () {
+    late String originalTempPath;
+
     final pdfBytes = Uint8List.fromList([
       0x25,
       0x50,
@@ -57,6 +59,14 @@ void main() {
       0x46,
       0x00,
     ]);
+
+    setUp(() {
+      originalTempPath = DocumentUtils.getTemporalFolderPath();
+    });
+
+    tearDown(() {
+      DocumentUtils.setTemporalFolderPath(originalTempPath);
+    });
 
     group('isPDF with bytes', () {
       test('returns true for PDF bytes', () async {
@@ -109,6 +119,43 @@ void main() {
         expect(result.startsWith(tempDir.path), isTrue);
         expect(File(result).existsSync(), isTrue);
 
+        await tempDir.delete(recursive: true);
+      });
+
+      test('preserves pdf extension for PDF bytes input', () async {
+        final tempDir = await Directory.systemTemp.createTemp('prep_pdf_test_');
+        DocumentUtils.setTemporalFolderPath(tempDir.path);
+
+        final result =
+            await DocumentUtils.prepareInput(MergeInput.bytes(pdfBytes));
+
+        expect(p.extension(result), '.pdf');
+        expect(File(result).existsSync(), isTrue);
+
+        await tempDir.delete(recursive: true);
+      });
+
+      test('downloads URL input to a temp file with detected extension', () async {
+        final tempDir = await Directory.systemTemp.createTemp('prep_url_test_');
+        final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+        DocumentUtils.setTemporalFolderPath(tempDir.path);
+
+        server.listen((request) async {
+          request.response.headers.contentType =
+              ContentType('application', 'pdf');
+          request.response.add(pdfBytes);
+          await request.response.close();
+        });
+
+        final url =
+            'http://${server.address.host}:${server.port}/document.pdf';
+        final result = await DocumentUtils.prepareInput(MergeInput.url(url));
+
+        expect(p.extension(result), '.pdf');
+        expect(File(result).existsSync(), isTrue);
+        expect(await DocumentUtils.isPDF(MergeInput.url(url)), isTrue);
+
+        await server.close(force: true);
         await tempDir.delete(recursive: true);
       });
     });

--- a/test/document_utils_bytes_test.dart
+++ b/test/document_utils_bytes_test.dart
@@ -70,13 +70,13 @@ void main() {
 
     group('isPDF with bytes', () {
       test('returns true for PDF bytes', () async {
-        final input = MergeInput.bytes(pdfBytes);
+        final input = MergeInputBytes(pdfBytes);
         final result = await DocumentUtils.isPDF(input);
         expect(result, isTrue);
       });
 
       test('returns false for non-PDF bytes', () async {
-        final input = MergeInput.bytes(pngBytes);
+        final input = MergeInputBytes(pngBytes);
         final result = await DocumentUtils.isPDF(input);
         expect(result, isFalse);
       });
@@ -84,19 +84,19 @@ void main() {
 
     group('isImage with bytes', () {
       test('returns true for PNG bytes', () async {
-        final input = MergeInput.bytes(pngBytes);
+        final input = MergeInputBytes(pngBytes);
         final result = await DocumentUtils.isImage(input);
         expect(result, isTrue);
       });
 
       test('returns true for JPG bytes', () async {
-        final input = MergeInput.bytes(jpgBytes);
+        final input = MergeInputBytes(jpgBytes);
         final result = await DocumentUtils.isImage(input);
         expect(result, isTrue);
       });
 
       test('returns false for PDF bytes', () async {
-        final input = MergeInput.bytes(pdfBytes);
+        final input = MergeInputBytes(pdfBytes);
         final result = await DocumentUtils.isImage(input);
         expect(result, isFalse);
       });
@@ -104,7 +104,7 @@ void main() {
 
     group('prepareInput', () {
       test('returns path for path type input', () async {
-        final input = MergeInput.path('/some/path.pdf');
+        final input = MergeInputPath('/some/path.pdf');
         final result = await DocumentUtils.prepareInput(input);
         expect(result, '/some/path.pdf');
       });
@@ -113,7 +113,7 @@ void main() {
         final tempDir = await Directory.systemTemp.createTemp('prep_test_');
         DocumentUtils.setTemporalFolderPath(tempDir.path);
 
-        final input = MergeInput.bytes(pngBytes);
+        final input = MergeInputBytes(pngBytes);
         final result = await DocumentUtils.prepareInput(input);
 
         expect(result.startsWith(tempDir.path), isTrue);
@@ -127,7 +127,7 @@ void main() {
         DocumentUtils.setTemporalFolderPath(tempDir.path);
 
         final result =
-            await DocumentUtils.prepareInput(MergeInput.bytes(pdfBytes));
+            await DocumentUtils.prepareInput(MergeInputBytes(pdfBytes));
 
         expect(p.extension(result), '.pdf');
         expect(File(result).existsSync(), isTrue);
@@ -149,11 +149,11 @@ void main() {
 
         final url =
             'http://${server.address.host}:${server.port}/document.pdf';
-        final result = await DocumentUtils.prepareInput(MergeInput.url(url));
+        final result = await DocumentUtils.prepareInput(MergeInputUrl(url));
 
         expect(p.extension(result), '.pdf');
         expect(File(result).existsSync(), isTrue);
-        expect(await DocumentUtils.isPDF(MergeInput.url(url)), isTrue);
+        expect(await DocumentUtils.isPDF(MergeInputUrl(url)), isTrue);
 
         await server.close(force: true);
         await tempDir.delete(recursive: true);

--- a/test/document_utils_test.dart
+++ b/test/document_utils_test.dart
@@ -178,7 +178,7 @@ void main() {
       final pdfPath = p.join(tempDir.path, 'test.pdf');
       await createFileWithBytes(pdfPath, pdfBytes);
 
-      final result = await DocumentUtils.isPDF(MergeInput.path(pdfPath));
+      final result = await DocumentUtils.isPDF(MergeInputPath(pdfPath));
       expect(result, isTrue);
 
       await Directory(tempDir.path).delete(recursive: true);
@@ -189,7 +189,7 @@ void main() {
       final pngPath = p.join(tempDir.path, 'image.png');
       await createFileWithBytes(pngPath, pngBytes);
 
-      final result = await DocumentUtils.isPDF(MergeInput.path(pngPath));
+      final result = await DocumentUtils.isPDF(MergeInputPath(pngPath));
       expect(result, isFalse);
 
       await Directory(tempDir.path).delete(recursive: true);
@@ -198,7 +198,7 @@ void main() {
     test('false when there is an exception (non-existent path)', () async {
       final nonExistent = p.join(Directory.systemTemp.path, 'no_such_file.pdf');
       expect(
-        () => DocumentUtils.isPDF(MergeInput.path(nonExistent)),
+        () => DocumentUtils.isPDF(MergeInputPath(nonExistent)),
         throwsA(isA<Exception>()),
       );
     });
@@ -211,7 +211,7 @@ void main() {
       final pngPath = p.join(tempDir.path, 'img.png');
       await createFileWithBytes(pngPath, pngBytes);
 
-      final result = await DocumentUtils.isImage(MergeInput.path(pngPath));
+      final result = await DocumentUtils.isImage(MergeInputPath(pngPath));
       expect(result, isTrue);
 
       await Directory(tempDir.path).delete(recursive: true);
@@ -223,7 +223,7 @@ void main() {
       final jpgPath = p.join(tempDir.path, 'img.jpg');
       await createFileWithBytes(jpgPath, jpgBytes);
 
-      final result = await DocumentUtils.isImage(MergeInput.path(jpgPath));
+      final result = await DocumentUtils.isImage(MergeInputPath(jpgPath));
       expect(result, isTrue);
 
       await Directory(tempDir.path).delete(recursive: true);
@@ -235,7 +235,7 @@ void main() {
       final pdfPath = p.join(tempDir.path, 'doc.pdf');
       await createFileWithBytes(pdfPath, pdfBytes);
 
-      final result = await DocumentUtils.isImage(MergeInput.path(pdfPath));
+      final result = await DocumentUtils.isImage(MergeInputPath(pdfPath));
       expect(result, isFalse);
 
       await Directory(tempDir.path).delete(recursive: true);
@@ -245,7 +245,7 @@ void main() {
       final nonExistent =
           p.join(Directory.systemTemp.path, 'no_such_image.png');
       expect(
-        () => DocumentUtils.isImage(MergeInput.path(nonExistent)),
+        () => DocumentUtils.isImage(MergeInputPath(nonExistent)),
         throwsA(isA<Exception>()),
       );
     });

--- a/test/merge_input_test.dart
+++ b/test/merge_input_test.dart
@@ -5,50 +5,53 @@ import 'package:pdf_combiner/models/merge_input.dart';
 
 void main() {
   group('MergeInput', () {
-    test('path constructor creates MergeInput with path type', () {
-      final input = MergeInput.path('/path/to/file.pdf');
+    test('MergeInputPath expone el path y no bytes/url', () {
+      final input = MergeInputPath('/path/to/file.pdf');
 
-      expect(input.type, MergeInputType.path);
+      expect(input, isA<MergeInputPath>());
       expect(input.path, '/path/to/file.pdf');
       expect(input.bytes, isNull);
-      expect(input.type == MergeInputType.bytes, isFalse);
+      expect(input.url, isNull);
+      expect(input.requiresTemporaryResource, isFalse);
     });
 
-    test('bytes constructor creates MergeInput with bytes type', () {
+    test('MergeInputBytes expone los bytes y requiere recurso temporal', () {
       final bytes = Uint8List.fromList([0x25, 0x50, 0x44, 0x46]);
-      final input = MergeInput.bytes(bytes);
+      final input = MergeInputBytes(bytes);
 
-      expect(input.type, MergeInputType.bytes);
+      expect(input, isA<MergeInputBytes>());
       expect(input.bytes, bytes);
       expect(input.path, isNull);
-      expect(input.type == MergeInputType.bytes, isTrue);
+      expect(input.url, isNull);
+      expect(input.requiresTemporaryResource, isTrue);
     });
 
-    test('url constructor creates MergeInput with url type', () {
-      final input = MergeInput.url('https://example.com/file.pdf');
+    test('MergeInputUrl expone la url y requiere recurso temporal', () {
+      final input = MergeInputUrl('https://example.com/file.pdf');
 
-      expect(input.type, MergeInputType.url);
+      expect(input, isA<MergeInputUrl>());
       expect(input.url, 'https://example.com/file.pdf');
       expect(input.path, isNull);
       expect(input.bytes, isNull);
       expect(input.sourceLabel, 'https://example.com/file.pdf');
+      expect(input.requiresTemporaryResource, isTrue);
     });
 
     test('toString returns path for path type', () {
-      final input = MergeInput.path('/path/to/file.pdf');
+      final input = MergeInputPath('/path/to/file.pdf');
 
       expect(input.toString(), '/path/to/file.pdf');
     });
 
     test('toString returns bytes string for bytes type', () {
       final bytes = Uint8List.fromList([0x25, 0x50, 0x44, 0x46]);
-      final input = MergeInput.bytes(bytes);
+      final input = MergeInputBytes(bytes);
 
       expect(input.toString(), bytes.toString());
     });
 
     test('sourceLabel returns friendly label for bytes type', () {
-      final input = MergeInput.bytes(Uint8List.fromList([1, 2, 3]));
+      final input = MergeInputBytes(Uint8List.fromList([1, 2, 3]));
 
       expect(input.sourceLabel, 'File in bytes');
     });

--- a/test/merge_input_test.dart
+++ b/test/merge_input_test.dart
@@ -24,6 +24,16 @@ void main() {
       expect(input.type == MergeInputType.bytes, isTrue);
     });
 
+    test('url constructor creates MergeInput with url type', () {
+      final input = MergeInput.url('https://example.com/file.pdf');
+
+      expect(input.type, MergeInputType.url);
+      expect(input.url, 'https://example.com/file.pdf');
+      expect(input.path, isNull);
+      expect(input.bytes, isNull);
+      expect(input.sourceLabel, 'https://example.com/file.pdf');
+    });
+
     test('toString returns path for path type', () {
       final input = MergeInput.path('/path/to/file.pdf');
 
@@ -35,6 +45,12 @@ void main() {
       final input = MergeInput.bytes(bytes);
 
       expect(input.toString(), bytes.toString());
+    });
+
+    test('sourceLabel returns friendly label for bytes type', () {
+      final input = MergeInput.bytes(Uint8List.fromList([1, 2, 3]));
+
+      expect(input.sourceLabel, 'File in bytes');
     });
   });
 }

--- a/test/pdf_combiner_combine_test.dart
+++ b/test/pdf_combiner_combine_test.dart
@@ -52,8 +52,8 @@ void main() {
       // Call the method and check the response.
       final result = await PdfCombiner.mergeMultiplePDFs(
         inputs: [
-          MergeInput.path('example/assets/document_1.pdf'),
-          MergeInput.path('example/assets/document_2.pdf'),
+          MergeInputPath('example/assets/document_1.pdf'),
+          MergeInputPath('example/assets/document_2.pdf'),
         ],
         outputPath: 'output/path.pdf',
       );
@@ -71,8 +71,8 @@ void main() {
       expect(
         () => PdfCombiner.mergeMultiplePDFs(
           inputs: [
-            MergeInput.path('example/assets/document_1.pdf'),
-            MergeInput.path('example/assets/document_2.pdf'),
+            MergeInputPath('example/assets/document_1.pdf'),
+            MergeInputPath('example/assets/document_2.pdf'),
           ],
           outputPath: 'output/path.jpeg',
         ),
@@ -114,8 +114,8 @@ void main() {
       expect(
         () => fakePlatformWithError.mergeMultiplePDFs(
           inputs: [
-            MergeInput.path('path1'),
-            MergeInput.path('path2'),
+            MergeInputPath('path1'),
+            MergeInputPath('path2'),
           ],
           outputPath: 'output/path.pdf',
         ),
@@ -135,8 +135,8 @@ void main() {
       expect(
         () => PdfCombiner.mergeMultiplePDFs(
           inputs: [
-            MergeInput.path('example/assets/document_1.pdf'),
-            MergeInput.path('example/assets/document_2.pdf'),
+            MergeInputPath('example/assets/document_1.pdf'),
+            MergeInputPath('example/assets/document_2.pdf'),
           ],
           outputPath: 'output/path.pdf',
         ),
@@ -156,8 +156,8 @@ void main() {
       expect(
         () => PdfCombiner.mergeMultiplePDFs(
           inputs: [
-            MergeInput.path('example/assets/document_1.pdf'),
-            MergeInput.path('example/assets/document_2.pdf'),
+            MergeInputPath('example/assets/document_1.pdf'),
+            MergeInputPath('example/assets/document_2.pdf'),
           ],
           outputPath: 'output/path.pdf',
         ),
@@ -177,8 +177,8 @@ void main() {
       expect(
         () => PdfCombiner.mergeMultiplePDFs(
           inputs: [
-            MergeInput.path('example/assets/document_1.pdf'),
-            MergeInput.path('example/assets/document_2.pdf'),
+            MergeInputPath('example/assets/document_1.pdf'),
+            MergeInputPath('example/assets/document_2.pdf'),
           ],
           outputPath: 'output/path.pdf',
         ),

--- a/test/pdf_combiner_create_images_from_pdf_test.dart
+++ b/test/pdf_combiner_create_images_from_pdf_test.dart
@@ -21,7 +21,7 @@ void main() {
 
       expect(
         () => PdfCombiner.createImageFromPDF(
-          input: MergeInput.path('example/assets/document_1.pdf'),
+          input: MergeInputPath('example/assets/document_1.pdf'),
           outputDirPath: 'output/path',
         ),
         throwsA(
@@ -39,7 +39,7 @@ void main() {
 
       expect(
         () => PdfCombiner.createImageFromPDF(
-          input: MergeInput.path('example/assets/document_1.pdf'),
+          input: MergeInputPath('example/assets/document_1.pdf'),
           outputDirPath: 'output/path',
         ),
         throwsA(
@@ -57,7 +57,7 @@ void main() {
 
       expect(
         () => PdfCombiner.createImageFromPDF(
-          input: MergeInput.path('example/assets/document_1.pdf'),
+          input: MergeInputPath('example/assets/document_1.pdf'),
           outputDirPath: 'output/path',
           config: ImageFromPdfConfig(
             rescale: ImageScale(width: 500, height: 200),
@@ -79,7 +79,7 @@ void main() {
 
       expect(
         () => PdfCombiner.createImageFromPDF(
-          input: MergeInput.path('example/assets/document_1.pdf'),
+          input: MergeInputPath('example/assets/document_1.pdf'),
           outputDirPath: 'output/path',
         ),
         throwsA(
@@ -97,7 +97,7 @@ void main() {
       final outputDirPath = 'output/path';
 
       final result = await PdfCombiner.createImageFromPDF(
-        input: MergeInput.path('example/assets/document_1.pdf'),
+        input: MergeInputPath('example/assets/document_1.pdf'),
         outputDirPath: outputDirPath,
         config: ImageFromPdfConfig(createOneImage: true),
       );
@@ -112,7 +112,7 @@ void main() {
       final outputDirPath = 'output/path';
 
       final result = await PdfCombiner.createImageFromPDF(
-        input: MergeInput.path('example/assets/document_1.pdf'),
+        input: MergeInputPath('example/assets/document_1.pdf'),
         outputDirPath: outputDirPath,
       );
 

--- a/test/pdf_combiner_create_pdf_from_multiple_images_test.dart
+++ b/test/pdf_combiner_create_pdf_from_multiple_images_test.dart
@@ -41,8 +41,8 @@ void main() {
       expect(
         () => PdfCombiner.createPDFFromMultipleImages(
           inputs: [
-            MergeInput.path('example/assets/image_1.jpeg'),
-            MergeInput.path('example/assets/image_2.png'),
+            MergeInputPath('example/assets/image_1.jpeg'),
+            MergeInputPath('example/assets/image_2.png'),
           ],
           outputPath: 'output/path.pdf',
         ),
@@ -62,8 +62,8 @@ void main() {
 
       final result = await PdfCombiner.createPDFFromMultipleImages(
         inputs: [
-          MergeInput.path('example/assets/image_1.jpeg'),
-          MergeInput.path('example/assets/image_2.png'),
+          MergeInputPath('example/assets/image_1.jpeg'),
+          MergeInputPath('example/assets/image_2.png'),
         ],
         outputPath: outputPath,
       );
@@ -80,8 +80,8 @@ void main() {
       expect(
         () => PdfCombiner.createPDFFromMultipleImages(
           inputs: [
-            MergeInput.path('example/assets/image_1.jpeg'),
-            MergeInput.path('example/assets/image_2.png'),
+            MergeInputPath('example/assets/image_1.jpeg'),
+            MergeInputPath('example/assets/image_2.png'),
           ],
           outputPath: outputPath,
         ),
@@ -104,8 +104,8 @@ void main() {
       expect(
         () => PdfCombiner.createPDFFromMultipleImages(
           inputs: [
-            MergeInput.path('example/assets/image_1.jpeg'),
-            MergeInput.path('example/assets/image_2.png'),
+            MergeInputPath('example/assets/image_1.jpeg'),
+            MergeInputPath('example/assets/image_2.png'),
           ],
           outputPath: 'output/path.pdf',
         ),
@@ -125,8 +125,8 @@ void main() {
       expect(
         () => PdfCombiner.createPDFFromMultipleImages(
           inputs: [
-            MergeInput.path('example/assets/image_1.jpeg'),
-            MergeInput.path('example/assets/image_2.png'),
+            MergeInputPath('example/assets/image_1.jpeg'),
+            MergeInputPath('example/assets/image_2.png'),
           ],
           outputPath: 'output/path.pdf',
         ),

--- a/test/pdf_combiner_from_documents_test.dart
+++ b/test/pdf_combiner_from_documents_test.dart
@@ -31,7 +31,7 @@ void main() {
 
       expect(
         () => PdfCombiner.generatePDFFromDocuments(
-          inputs: [MergeInput.path('any')],
+          inputs: [MergeInputPath('any')],
           outputPath: '   ',
         ),
         throwsA(

--- a/test/pdf_combiner_generate_from_documents_test.dart
+++ b/test/pdf_combiner_generate_from_documents_test.dart
@@ -46,8 +46,8 @@ void main() {
 
       final result = await PdfCombiner.generatePDFFromDocuments(
         inputs: [
-          MergeInput.path('example/assets/document_1.pdf'),
-          MergeInput.path('example/assets/document_2.pdf'),
+          MergeInputPath('example/assets/document_1.pdf'),
+          MergeInputPath('example/assets/document_2.pdf'),
         ],
         outputPath: 'output/path.pdf',
       );
@@ -62,8 +62,8 @@ void main() {
       expect(
         () => PdfCombiner.generatePDFFromDocuments(
           inputs: [
-            MergeInput.path('example/assets/image_1.jpeg'),
-            MergeInput.path('example/assets/document_1.pdf'),
+            MergeInputPath('example/assets/image_1.jpeg'),
+            MergeInputPath('example/assets/document_1.pdf'),
           ],
           outputPath: 'path.jpg',
         ),
@@ -84,8 +84,8 @@ void main() {
       expect(
         () => PdfCombiner.generatePDFFromDocuments(
           inputs: [
-            MergeInput.path('example/assets/document_1.pdf'),
-            MergeInput.path('example/assets/image_1.jpeg'),
+            MergeInputPath('example/assets/document_1.pdf'),
+            MergeInputPath('example/assets/image_1.jpeg'),
           ],
           outputPath: '',
         ),
@@ -127,8 +127,8 @@ void main() {
       expect(
         () => PdfCombiner.generatePDFFromDocuments(
           inputs: [
-            MergeInput.path('example/assets/document_1.pdf'),
-            MergeInput.path('example/assets/document_2.pdf'),
+            MergeInputPath('example/assets/document_1.pdf'),
+            MergeInputPath('example/assets/document_2.pdf'),
           ],
           outputPath: 'output/path.pdf',
         ),
@@ -148,8 +148,8 @@ void main() {
       expect(
         () => PdfCombiner.generatePDFFromDocuments(
           inputs: [
-            MergeInput.path('example/assets/document_1.pdf'),
-            MergeInput.path('example/assets/document_2.pdf'),
+            MergeInputPath('example/assets/document_1.pdf'),
+            MergeInputPath('example/assets/document_2.pdf'),
           ],
           outputPath: 'output/path.pdf',
         ),
@@ -169,7 +169,7 @@ void main() {
       expect(
         () => PdfCombiner.generatePDFFromDocuments(
           inputs: [
-            MergeInput.path('example/assets/image_1.jpeg'),
+            MergeInputPath('example/assets/image_1.jpeg'),
           ],
           outputPath: 'output/path.pdf',
         ),

--- a/test/pdf_combiner_merge_error_response_test.dart
+++ b/test/pdf_combiner_merge_error_response_test.dart
@@ -89,8 +89,8 @@ void main() {
         expect(
           () async => await PdfCombiner.mergeMultiplePDFs(
             inputs: [
-              MergeInput.path('example/assets/document_1.pdf'),
-              MergeInput.path('example/assets/document_2.pdf'),
+              MergeInputPath('example/assets/document_1.pdf'),
+              MergeInputPath('example/assets/document_2.pdf'),
             ],
             outputPath: 'output.pdf',
           ),
@@ -107,8 +107,8 @@ void main() {
         expect(
           () async => await PdfCombiner.mergeMultiplePDFs(
             inputs: [
-              MergeInput.path('example/assets/document_1.pdf'),
-              MergeInput.path('example/assets/document_2.pdf'),
+              MergeInputPath('example/assets/document_1.pdf'),
+              MergeInputPath('example/assets/document_2.pdf'),
             ],
             outputPath: 'output.pdf',
           ),
@@ -135,7 +135,7 @@ void main() {
           try {
             await expectLater(
               () => PdfCombiner.createPDFFromMultipleImages(
-                inputs: [MergeInput.path(file1.path)],
+                inputs: [MergeInputPath(file1.path)],
                 outputPath: 'output_images.pdf',
               ),
               throwsA(isA<PdfCombinerException>()
@@ -166,7 +166,7 @@ void main() {
           try {
             await expectLater(
               () => PdfCombiner.createPDFFromMultipleImages(
-                inputs: [MergeInput.path(file1.path)],
+                inputs: [MergeInputPath(file1.path)],
                 outputPath: 'output_images.pdf',
               ),
               throwsA(isA<PdfCombinerException>().having((e) => e.message,
@@ -200,7 +200,7 @@ void main() {
         try {
           expect(
             () async => await PdfCombiner.createImageFromPDF(
-              input: MergeInput.path('input.pdf'),
+              input: MergeInputPath('input.pdf'),
               outputDirPath: 'output_dir',
             ),
             throwsA(isA<PdfCombinerException>()

--- a/test/pdf_combiner_method_channel_error_test.dart
+++ b/test/pdf_combiner_method_channel_error_test.dart
@@ -16,8 +16,8 @@ void main() {
       expect(
         () async => await PdfCombinerPlatform.instance.mergeMultiplePDFs(
           inputs: [
-            MergeInput.path('path/to/pdf1.pdf'),
-            MergeInput.path('path/to/pdf2.pdf'),
+            MergeInputPath('path/to/pdf1.pdf'),
+            MergeInputPath('path/to/pdf2.pdf'),
           ],
           outputPath: 'path/to/output.pdf',
         ),
@@ -29,8 +29,8 @@ void main() {
       expect(
         () async => await PdfCombinerPlatform.instance
             .createPDFFromMultipleImages(inputs: [
-          MergeInput.path('path/to/image1.png'),
-          MergeInput.path('path/to/image2.png'),
+          MergeInputPath('path/to/image1.png'),
+          MergeInputPath('path/to/image2.png'),
         ], outputPath: 'path/to/output.pdf'),
         throwsA(isA<UnimplementedError>()),
       );
@@ -39,7 +39,7 @@ void main() {
     test('createImageFromPDF throws UnimplementedError', () async {
       expect(
         () async => await PdfCombinerPlatform.instance.createImageFromPDF(
-          input: MergeInput.path('path/to/pdf.pdf'),
+          input: MergeInputPath('path/to/pdf.pdf'),
           outputPath: 'path/to/output/images',
         ),
         throwsA(isA<UnimplementedError>()),

--- a/test/pdf_combiner_method_channel_test.dart
+++ b/test/pdf_combiner_method_channel_test.dart
@@ -34,8 +34,8 @@ void main() {
 
     final result = await platform.mergeMultiplePDFs(
       inputs: [
-        MergeInput.path('file1.pdf'),
-        MergeInput.path('file2.pdf'),
+        MergeInputPath('file1.pdf'),
+        MergeInputPath('file2.pdf'),
       ],
       outputPath: '/output/path',
     );
@@ -61,8 +61,8 @@ void main() {
 
     final result = await platform.createPDFFromMultipleImages(
       inputs: [
-        MergeInput.path('image1.jpg'),
-        MergeInput.path('image2.png'),
+        MergeInputPath('image1.jpg'),
+        MergeInputPath('image2.png'),
       ],
       outputPath: '/output/path',
     );
@@ -88,7 +88,7 @@ void main() {
     });
 
     final result = await platform.createImageFromPDF(
-      input: MergeInput.path('file.pdf'),
+      input: MergeInputPath('file.pdf'),
       outputPath: '/output/path',
       config: ImageFromPdfConfig(
           rescale: ImageScale(width: 400, height: 400), createOneImage: false),

--- a/test/pdf_combiner_pdf_generation_test.dart
+++ b/test/pdf_combiner_pdf_generation_test.dart
@@ -71,7 +71,7 @@ void main() {
 
         expect(
           () => PdfCombiner.generatePDFFromDocuments(
-            inputs: [MergeInput.path(txtFile.path)],
+            inputs: [MergeInputPath(txtFile.path)],
             outputPath: '$tempPath/output.pdf',
           ),
           throwsA(
@@ -91,8 +91,8 @@ void main() {
 
         final result = await PdfCombiner.generatePDFFromDocuments(
           inputs: [
-            MergeInput.path('example/assets/image_1.jpeg'),
-            MergeInput.path('example/assets/document_1.pdf'),
+            MergeInputPath('example/assets/image_1.jpeg'),
+            MergeInputPath('example/assets/document_1.pdf'),
           ],
           outputPath: '$tempPath/output.pdf',
         );
@@ -108,7 +108,7 @@ void main() {
 
         expect(
           () => PdfCombiner.mergeMultiplePDFs(
-            inputs: [MergeInput.path(txtFile.path)],
+            inputs: [MergeInputPath(txtFile.path)],
             outputPath: '$tempPath/output.pdf',
           ),
           throwsA(
@@ -138,7 +138,7 @@ void main() {
         ]);
 
         final result = await PdfCombiner.mergeMultiplePDFs(
-          inputs: [MergeInput.bytes(pdfBytes)],
+          inputs: [MergeInputBytes(pdfBytes)],
           outputPath: '$tempPath/output.pdf',
         );
 
@@ -153,7 +153,7 @@ void main() {
 
         expect(
           () => PdfCombiner.createPDFFromMultipleImages(
-            inputs: [MergeInput.path(txtFile.path)],
+            inputs: [MergeInputPath(txtFile.path)],
             outputPath: '$tempPath/output.pdf',
           ),
           throwsA(
@@ -182,7 +182,7 @@ void main() {
         ]);
 
         final result = await PdfCombiner.createPDFFromMultipleImages(
-          inputs: [MergeInput.bytes(pngBytes)],
+          inputs: [MergeInputBytes(pngBytes)],
           outputPath: '$tempPath/output.pdf',
         );
 
@@ -197,7 +197,7 @@ void main() {
 
         expect(
           () => PdfCombiner.createImageFromPDF(
-            input: MergeInput.path(txtFile.path),
+            input: MergeInputPath(txtFile.path),
             outputDirPath: tempPath,
           ),
           throwsA(
@@ -216,7 +216,7 @@ void main() {
 
         expect(
           () => PdfCombiner.createImageFromPDF(
-            input: MergeInput.bytes(notPdfBytes),
+            input: MergeInputBytes(notPdfBytes),
             outputDirPath: tempPath,
           ),
           throwsA(
@@ -245,7 +245,7 @@ void main() {
         ]);
 
         final result = await PdfCombiner.createImageFromPDF(
-          input: MergeInput.bytes(pdfBytes),
+          input: MergeInputBytes(pdfBytes),
           outputDirPath: tempPath,
         );
 
@@ -270,7 +270,7 @@ void main() {
         ]);
 
         final result =
-            await DocumentUtils.prepareInput(MergeInput.bytes(pngBytes));
+            await DocumentUtils.prepareInput(MergeInputBytes(pngBytes));
 
         expect(result.startsWith(nonExistentPath), isTrue);
         expect(Directory(nonExistentPath).existsSync(), isTrue);

--- a/test/test_pdf_combiner.dart
+++ b/test/test_pdf_combiner.dart
@@ -20,7 +20,7 @@ void main() {
       });
       DocumentUtils.setTemporalFolderPath("./example/assets/temp");
       var result = await PdfCombiner.generatePDFFromDocuments(
-        inputs: [MergeInput.path("./example/assets/image_1.jpeg")],
+        inputs: [MergeInputPath("./example/assets/image_1.jpeg")],
         outputPath: "./example/assets/temp/document_0.pdf",
       );
       expect(result, "./example/assets/temp/document_0.pdf");


### PR DESCRIPTION
refactor: use explicit subclasses for MergeInput and remove enum-based factories

- Replaces `MergeInput` factory constructors (`.path`, `.bytes`, `.url`) with concrete subclasses: `MergeInputPath`, `MergeInputBytes`, and `MergeInputUrl`.
- Removes the `MergeInputType` enum, favoring polymorphism and pattern matching across the library and internal utilities.
- Adds `requiresTemporaryResource` and `temporaryFilePrefix` properties to `MergeInput` to encapsulate temporary file logic.
- Updates the example app, integration tests, and unit tests to use the new explicit input classes.
- Introduces `InputSourceType` in the example app to handle UI-specific source selection.
- Refactors `DocumentUtils` to use pattern matching for input preparation and file type detection.