### PR TITLE
Upgrade actions/checkout and related actions to v6

### DIFF
--- a/.github/workflows/android_integration_test.yml
+++ b/.github/workflows/android_integration_test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Enable KVM
         run: |
@@ -19,13 +19,13 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: 17
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Setup Flutter SDK
         uses: flutter-actions/setup-flutter@v4

--- a/.github/workflows/dart_analyze_unit_test.yml
+++ b/.github/workflows/dart_analyze_unit_test.yml
@@ -12,7 +12,7 @@ jobs:
         sdk: [stable]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Flutter SDK
         uses: flutter-actions/setup-flutter@v4
@@ -30,7 +30,7 @@ jobs:
         run: flutter test --coverage
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: vicajilau/pdf_combiner

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
@@ -39,15 +39,15 @@ jobs:
         run: flutter build web --release --base-href /${{ github.event.repository.name }}/
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
         with:
           enablement: true
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: "./example/build/web"
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/ios_integration_test.yml
+++ b/.github/workflows/ios_integration_test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install MacOS Dependencies
         run: |

--- a/.github/workflows/linux_integration_test.yml
+++ b/.github/workflows/linux_integration_test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Linux Dependencies
         run: |

--- a/.github/workflows/macos_integration_test.yml
+++ b/.github/workflows/macos_integration_test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install MacOS Dependencies
         run: |

--- a/.github/workflows/windows_integration_test.yml
+++ b/.github/workflows/windows_integration_test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Flutter SDK
         uses: flutter-actions/setup-flutter@v4


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to use the latest versions of several key actions. The main goal is to keep the CI/CD pipelines up-to-date with the most recent features, improvements, and security patches provided by these actions.

**Workflow action version upgrades:**

*General upgrade to latest action versions:*
- Updated `actions/checkout` from `v4` to `v6` across all workflows for improved performance and security. [[1]](diffhunk://#diff-a14105145446ace5f90b4bc3084624fcd26343a254241da87b30c74e6ef7e64bL13-R13) [[2]](diffhunk://#diff-3c890721a14e1e99672d45c435a61452193c1685e4305bee3ffc37898519f626L15-R15) [[3]](diffhunk://#diff-875a32a9bd9123a01ecb0b1802809c712a8a04f695e979c262eb9380e6359efcL24-R24) [[4]](diffhunk://#diff-4955eeec511c07cf3a92569ef90a791896d3b515e82c5d0fc754d67edbc8739fL13-R13) [[5]](diffhunk://#diff-4d02607ac6551395e4d62eeca695d2253ce55f75ef6b817f2f55827bf8fd1852L13-R13) [[6]](diffhunk://#diff-dc6db0cb57e877eb285d380e46f57d5c280639dc7d047f198d91abf0d2483eeaL13-R13) [[7]](diffhunk://#diff-dc3f2e581b9923e8fb6c4a93b6a157832d38b22cff9fcd55be87c28ded63e56bL13-R13)

*Android and build-related workflows:*
- Updated `actions/setup-java` from `v4` to `v5` and `gradle/actions/setup-gradle` from `v4` to `v6` in `android_integration_test.yml` for better Java and Gradle support.
- Updated `codecov/codecov-action` from `v5` to `v6` in `dart_analyze_unit_test.yml` to ensure compatibility with the latest Codecov features.

*Web deployment workflow:*
- Updated `actions/configure-pages` from `v4` to `v6`, `actions/upload-pages-artifact` from `v3` to `v5`, and `actions/deploy-pages` from `v4` to `v5` in `deploy-web.yml` for improved GitHub Pages deployment reliability and features.