### PR TITLE
fix(ios,macos): fix EXC_BAD_ACCESS crash when merging PDFs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,6 +7,8 @@
 *.yaml text eol=lf
 pubspec.lock text eol=lf
 pubspec.yaml text eol=lf
+*.cmake text eol=lf
+CMakeLists.txt text eol=lf
 
 # Source files - always use LF
 *.java text eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 6.1.1
+
+### iOS & macOS
+
+* Fixed a critical crash (`EXC_BAD_ACCESS` in `CGPDFAdvancesGetHorizontalAdvance`) when merging multiple PDF files caused by premature deallocation of source `PDFDocument` objects. [#156](https://github.com/vicajilau/pdf_combiner/issues/156)
+* Simplified page creation helper using native `PDFPage(image:)` initialization.
+
 ## 6.1.0
 
 ### General

--- a/ios/pdf_combiner/Sources/pdf_combiner/PdfCombinerPlugin.swift
+++ b/ios/pdf_combiner/Sources/pdf_combiner/PdfCombinerPlugin.swift
@@ -76,9 +76,11 @@ private extension PdfCombinerPlugin {
         }
         let mergedPDF = PDFDocument()
         var pageIndex = 0
+        var sourceDocuments: [PDFDocument] = []
         
         for path in paths {
             guard let pdfDocument = PDFDocument(url: URL(fileURLWithPath: path)) else { continue }
+            sourceDocuments.append(pdfDocument)
 
             for index in 0..<pdfDocument.pageCount {
                 guard let page = pdfDocument.page(at: index) else { continue }
@@ -267,27 +269,8 @@ private extension PdfCombinerPlugin {
     }
     
     func createNewPage(with image: UIImage) -> PDFPage? {
-           let pdfData = NSMutableData()
-           var mediaBox = CGRect(origin: .zero, size: image.size)
-           guard let consumer = CGDataConsumer(data: pdfData as CFMutableData),
-                 let context = CGContext(consumer: consumer, mediaBox: &mediaBox, nil) else {
-               return nil
-           }
-              
-           context.beginPDFPage(nil)
-              
-           let cgImage = image.cgImage
-           context.draw(cgImage!, in: mediaBox)
-              
-           context.endPDFPage()
-           context.closePDF()
-              
-           if let document = PDFDocument(data: pdfData as Data),
-               let page = document.page(at: 0) {
-               return page
-           }
-           return nil
-       }
+        return PDFPage(image: image)
+    }
 }
 
 extension UIDevice {

--- a/macos/pdf_combiner/Sources/pdf_combiner/PdfCombinerPlugin.swift
+++ b/macos/pdf_combiner/Sources/pdf_combiner/PdfCombinerPlugin.swift
@@ -77,9 +77,11 @@ private extension PdfCombinerPlugin {
 
         let mergedPDF = PDFDocument()
         var pageIndex = 0
+        var sourceDocuments: [PDFDocument] = []
         
         for path in paths {
             guard let pdfDocument = PDFDocument(url: URL(fileURLWithPath: path)) else { continue }
+            sourceDocuments.append(pdfDocument)
 
             for index in 0..<pdfDocument.pageCount {
                 guard let page = pdfDocument.page(at: index) else { continue }
@@ -272,26 +274,7 @@ private extension PdfCombinerPlugin {
     }
     
     func createNewPage(with image: NSImage) -> PDFPage? {
-        let pdfData = NSMutableData()
-        var mediaBox = CGRect(origin: .zero, size: image.size)
-        guard let consumer = CGDataConsumer(data: pdfData as CFMutableData),
-              let context = CGContext(consumer: consumer, mediaBox: &mediaBox, nil) else {
-            return nil
-        }
-           
-        context.beginPDFPage(nil)
-           
-        let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil)
-        context.draw(cgImage!, in: mediaBox)
-           
-        context.endPDFPage()
-        context.closePDF()
-           
-        if let document = PDFDocument(data: pdfData as Data),
-            let page = document.page(at: 0) {
-            return page
-        }
-        return nil
+        return PDFPage(image: image)
     }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pdf_combiner
 description: "It is a lightweight and efficient Flutter plugin designed to merge multiple PDF documents into a single file effortlessly."
-version: 6.1.0
+version: 6.1.1
 homepage: https://github.com/vicajilau/pdf_combiner
 
 environment:


### PR DESCRIPTION
Resolves #156.

This PR fixes the EXC_BAD_ACCESS crash when merging multiple PDF files on iOS and macOS.

### Cause
In mergeMultiplePDF, the pdfDocument variable went out of scope and was deallocated inside the loop. However, the PDFPage objects inserted into the merged document still refer back to the original documents. Writing the merged document triggered invalid memory access.
Similarly, createNewPage returned a page whose temporary parent document was immediately deallocated.

### Fix
- Retain source documents in sourceDocuments inside mergeMultiplePDF.
- Use the native PDFPage(image:) initializer directly in createNewPage.