### PR TITLE
fix(android): avoid pinning the Kotlin Gradle plugin version

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("com.android.library")
-    id("org.jetbrains.kotlin.android") version "2.2.21"
+    id("org.jetbrains.kotlin.android")
 }
 
 group = "com.victorcarreras.pdf_combiner"


### PR DESCRIPTION
## Summary

- remove the explicit Kotlin Gradle plugin version from the Android library
- inherit the Kotlin plugin version selected by the consuming Flutter project

## Why

Flutter applications already declare their Kotlin Gradle plugin version in their root Android settings. Pinning Kotlin 2.2.21 inside pdf_combiner causes Gradle plugin classpath conflicts when an application uses another version, such as 2.4.10.

This change lets Gradle resolve the Kotlin plugin version from the consuming application while preserving the existing plugin configuration.

## Validation

- flutter analyze
- flutter test: 100 tests passed