### PR TITLE
fix(android): migrate jvmTarget to the compilerOptions DSL (fixes build with Kotlin 2.3+)

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
@@ -20,13 +22,15 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
-
     sourceSets {
         getByName("main").java.srcDir("src/main/kotlin")
         getByName("test").java.srcDir("src/test/kotlin")
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_1_8)
     }
 }
 


### PR DESCRIPTION
## Problem

Kotlin Gradle plugin 2.3+ turned the `kotlinOptions.jvmTarget: String` setter from a deprecation warning into a hard error. Since 6.2.1 removed the pinned KGP version so the library inherits the consuming project's version, any app on KGP 2.3+ now fails to build:

```
e: file:///…/pub-cache/hosted/pub.dev/pdf_combiner-6.2.1/android/build.gradle.kts:24:9:
   Using 'jvmTarget: String' is an error. Please migrate to the compilerOptions DSL.
   More details are here: https://kotl.in/u1r8ln

FAILURE: Build failed with an exception.
* Where: Build file '…/pdf_combiner-6.2.1/android/build.gradle.kts' line: 24
* What went wrong: Script compilation error
```

Because this is a *build-script compilation* failure inside the published package, it happens before any consumer hook (`subprojects {}`, `afterEvaluate {}`, …) can run — so downstream projects have no way to work around it other than pinning Kotlin back below 2.3 or staying on an older `pdf_combiner`.

## Change

Migrates `android/build.gradle.kts` from the removed `kotlinOptions` DSL to the current `kotlin { compilerOptions { … } }` DSL. The effective JVM target is unchanged (1.8), and the new DSL has been supported since KGP 1.8, so this stays compatible with older consumer plugin versions too.

## Verification

Built a Flutter app that depends on this branch via `dependency_overrides`, with `org.jetbrains.kotlin.android` 2.4.10 / AGP 8.13.2 / Gradle 8.14.5:

```
✓ Built build/app/outputs/flutter-apk/app-debug.apk
```

The same app fails on 6.2.1 with the error above.

## Note

`example/android/app/build.gradle.kts` still uses `kotlinOptions` too. It doesn't break today because the example pins KGP 2.2.21, but it will hit the same error whenever that pin moves to 2.3+. Left out of this PR to keep the fix focused — happy to include it if you'd prefer.

Opened as a draft — let me know if you'd like the CHANGELOG entry / version bump included and I'll add it.
